### PR TITLE
Use struct{} instead of int as context key

### DIFF
--- a/gocontext.go
+++ b/gocontext.go
@@ -2,9 +2,9 @@ package opentracing
 
 import "golang.org/x/net/context"
 
-type contextKey int
+type contextKey struct{}
 
-const activeSpanKey contextKey = iota
+var activeSpanKey = contextKey{}
 
 // ContextWithSpan returns a new `context.Context` that holds a reference to
 // the given `Span`.


### PR DESCRIPTION
The line

```go
  val := ctx.Value(activeSpanKey)
```

previously allocated to pass the integer
`activeSpanKey` as an interface. With this
change, no such allocation is necessary.

This showed up during benchmarks in
cockroachdb/cockroach.