### PR TITLE
Fix multiple bugs in standard SpanPropagator

### DIFF
--- a/standardtracer/spanpropagator.go
+++ b/standardtracer/spanpropagator.go
@@ -178,11 +178,6 @@ func (s *tracerImpl) JoinTraceFromText(
 		return nil, fmt.Errorf("Only found %v of 3 required fields", requiredFieldCount)
 	}
 
-	lcAttrsMap := make(map[string]string, len(attrsMap))
-	for k, v := range attrsMap {
-		lcAttrsMap[strings.ToLower(k)] = v
-	}
-
 	return s.startSpanGeneric(
 			operationName,
 			&StandardContext{
@@ -190,7 +185,7 @@ func (s *tracerImpl) JoinTraceFromText(
 				SpanID:       randomID(),
 				ParentSpanID: propagatedSpanID,
 				Sampled:      sampled,
-				traceAttrs:   lcAttrsMap,
+				traceAttrs:   attrsMap,
 			}),
 		nil
 }

--- a/standardtracer/spanpropagator.go
+++ b/standardtracer/spanpropagator.go
@@ -143,7 +143,7 @@ func (s *tracerImpl) JoinTraceFromBinary(
 func (s *tracerImpl) JoinTraceFromText(
 	operationName string,
 	contextIDMap map[string]string,
-	tagsMap map[string]string,
+	attrsMap map[string]string,
 ) (opentracing.Span, error) {
 	requiredFieldCount := 0
 	var traceID, spanID int64
@@ -177,9 +177,9 @@ func (s *tracerImpl) JoinTraceFromText(
 		return nil, fmt.Errorf("Only found %v of 3 required fields", requiredFieldCount)
 	}
 
-	lowercaseTagsMap := make(map[string]string, len(tagsMap))
-	for k, v := range tagsMap {
-		lowercaseTagsMap[strings.ToLower(k)] = v
+	lcAttrsMap := make(map[string]string, len(attrsMap))
+	for k, v := range attrsMap {
+		lcAttrsMap[strings.ToLower(k)] = v
 	}
 
 	return s.startSpanGeneric(
@@ -188,7 +188,7 @@ func (s *tracerImpl) JoinTraceFromText(
 				TraceID:    traceID,
 				SpanID:     spanID,
 				Sampled:    sampled,
-				traceAttrs: lowercaseTagsMap,
+				traceAttrs: lcAttrsMap,
 			}),
 		nil
 }

--- a/standardtracer/spanpropagator_test.go
+++ b/standardtracer/spanpropagator_test.go
@@ -1,0 +1,62 @@
+package standardtracer_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/standardtracer"
+	"github.com/opentracing/opentracing-go/testutils"
+)
+
+func TestSpanPropagator(t *testing.T) {
+	const op = "test"
+	recorder := testutils.NewInMemoryRecorder()
+	tracer := standardtracer.New(recorder)
+
+	sp := tracer.StartTrace(op)
+	sp.SetTraceAttribute("foo", "bar")
+
+	textCtx, textAttrs := tracer.PropagateSpanAsText(sp)
+	binCtx, binAttrs := tracer.PropagateSpanAsBinary(sp)
+
+	sp1, err := tracer.JoinTraceFromText(op, textCtx, textAttrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp2, err := tracer.JoinTraceFromBinary(op, binCtx, binAttrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp.Finish()
+	for _, sp := range []opentracing.Span{sp1, sp2} {
+		sp.Finish()
+	}
+
+	spans := recorder.GetSpans()
+	if a, e := len(spans), 3; a != e {
+		t.Fatalf("expected %d spans, got %d", e, a)
+	}
+
+	exp := spans[0]
+	exp.Duration = time.Duration(123)
+	exp.Start = time.Time{}.Add(1)
+
+	for i, sp := range spans[1:] {
+		if a, e := sp.ParentSpanID, exp.SpanID; a != e {
+			t.Errorf("%d: ParentSpanID %d does not match expectation %d", i, a, e)
+		} else {
+			// Prepare for comparison.
+			sp.SpanID, sp.ParentSpanID = exp.SpanID, 0
+			sp.Duration, sp.Start = exp.Duration, exp.Start
+		}
+		if a, e := sp.TraceID, exp.TraceID; a != e {
+			t.Errorf("%d: TraceID changed from %d to %d", i, e, a)
+		}
+		if !reflect.DeepEqual(exp, sp) {
+			t.Errorf("%d: wanted %+v, got %+v", i, spew.Sdump(exp), spew.Sdump(sp))
+		}
+	}
+}


### PR DESCRIPTION
Fixed the following bugs:

- JoinTraceFromBinary reconstructed, but didn't use the
  attributes map
- JoinTraceFromBinary contained calls to binary.Read which
  attempted to read into type `int`, which is a runtime panic.
- JoinTraceFromText did not create a new span, but returned a
  Span with identical SpanID and no parent instead.

Added a test that exercises all of the above.

Two further commits contain unrelated minor fixes.