### PR TITLE
Export NoopTracer

### DIFF
--- a/globaltracer.go
+++ b/globaltracer.go
@@ -1,7 +1,7 @@
 package opentracing
 
 var (
-	globalTracer Tracer = noopTracer{}
+	globalTracer Tracer = NoopTracer{}
 )
 
 // InitGlobalTracer sets the [singleton] opentracing.Tracer returned by

--- a/noop.go
+++ b/noop.go
@@ -1,11 +1,14 @@
 package opentracing
 
+// A NoopTracer is a trivial implementation of Tracer for which all operations
+// are no-ops.
+type NoopTracer struct{}
+
 type noopSpan struct{}
-type noopTracer struct{}
 
 var (
 	defaultNoopSpan   = noopSpan{}
-	defaultNoopTracer = noopTracer{}
+	defaultNoopTracer = NoopTracer{}
 	emptyTags         = Tags{}
 	emptyBytes        = []byte{}
 	emptyStringMap    = map[string]string{}
@@ -28,21 +31,27 @@ func (n noopSpan) LogEventWithPayload(event string, payload interface{}) {}
 func (n noopSpan) Log(data LogData)                                      {}
 func (n noopSpan) SetOperationName(operationName string) Span            { return n }
 
-// noopTracer:
-func (n noopTracer) PropagateSpanAsBinary(tcid Span) ([]byte, []byte) {
+// PropagateSpanAsBinary belongs to the Tracer interface.
+func (n NoopTracer) PropagateSpanAsBinary(tcid Span) ([]byte, []byte) {
 	return emptyBytes, emptyBytes
 }
-func (n noopTracer) PropagateSpanAsText(tcid Span) (map[string]string, map[string]string) {
+
+// PropagateSpanAsText belongs to the Tracer interface.
+func (n NoopTracer) PropagateSpanAsText(tcid Span) (map[string]string, map[string]string) {
 	return emptyStringMap, emptyStringMap
 }
-func (n noopTracer) JoinTraceFromBinary(
+
+// JoinTraceFromBinary belongs to the Tracer interface.
+func (n NoopTracer) JoinTraceFromBinary(
 	op string,
 	traceContextID []byte,
 	traceAttrs []byte,
 ) (Span, error) {
 	return defaultNoopSpan, nil
 }
-func (n noopTracer) JoinTraceFromText(
+
+// JoinTraceFromText belongs to the Tracer interface.
+func (n NoopTracer) JoinTraceFromText(
 	op string,
 	traceContextID map[string]string,
 	traceAttrs map[string]string,
@@ -50,10 +59,12 @@ func (n noopTracer) JoinTraceFromText(
 	return defaultNoopSpan, nil
 }
 
-func (n noopTracer) StartTrace(operationName string) Span {
+// StartTrace belongs to the Tracer interface.
+func (n NoopTracer) StartTrace(operationName string) Span {
 	return defaultNoopSpan
 }
 
-func (n noopTracer) JoinTrace(operationName string, parent interface{}) Span {
+// JoinTrace belongs to the Tracer interface.
+func (n NoopTracer) JoinTrace(operationName string, parent interface{}) Span {
 	return defaultNoopSpan
 }

--- a/span.go
+++ b/span.go
@@ -88,8 +88,8 @@ type Span interface {
 	TraceAttribute(restrictedKey string) string
 }
 
-// See Span.Log(). Every LogData instance should specify at least one of Event
-// and/or Payload.
+// LogData is data associated to a Span. Every LogData instance should specify
+// at least one of Event and/or Payload.
 type LogData struct {
 	// The timestamp of the log record; if set to the default value (the unix
 	// epoch), implementations should use time.Now() implicitly.

--- a/utils.go
+++ b/utils.go
@@ -32,7 +32,7 @@ func PropagateSpanInHeader(
 	}
 }
 
-// NewSpanFromHeader decodes a Span with operation name `operationName` from
+// JoinTraceFromHeader decodes a Span with operation name `operationName` from
 // `h`, expecting that header values are URL-escpaed.
 //
 // If `operationName` is empty, the caller must later call


### PR DESCRIPTION
It is used as the default value for the
package-level singleton, but allowing
external packages to make use of it is
a benefit.

Minor other code changes to have passing
`go vet ./...` and `golint`.

Any plans for CI on this repo? The current
state of affairs is somewhat sad.