### PR TITLE
Fix the fix in #44

### DIFF
--- a/standardtracer/spanpropagator.go
+++ b/standardtracer/spanpropagator.go
@@ -46,7 +46,7 @@ func (s *tracerImpl) PropagateSpanAsBinary(
 	sc := sp.(*spanImpl).raw.StandardContext
 	var err error
 	var sampledByte byte = 0
-	if !sc.Sampled {
+	if sc.Sampled {
 		sampledByte = 1
 	}
 


### PR DESCRIPTION
namely setting Sampled on the child whenever
it was **not** set on the parent.

Caught by the test from #42. Much can be won
by a simple one-liner setup on Travis/CircleCI,
pre-stabilization or not. The current situation
is frankly a little insane.

Happy to set that up, just need the corresponding
rights on the repository.