### PR TITLE
consolidate span creation methods

### DIFF
--- a/examples/dapperish.go
+++ b/examples/dapperish.go
@@ -19,7 +19,7 @@ func client() {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		ctx, span := opentracing.BackgroundContextWithSpan(
-			opentracing.StartTrace("getInput"))
+			opentracing.StartSpan("getInput"))
 		// Make sure that global trace tag propagation works.
 		span.SetTraceAttribute("User", os.Getenv("USER"))
 		span.LogEventWithPayload("ctx", ctx)

--- a/ext/tags_test.go
+++ b/ext/tags_test.go
@@ -15,7 +15,7 @@ func TestPeerTags(t *testing.T) {
 	}
 	recorder := testutils.NewInMemoryRecorder()
 	tracer := standardtracer.New(recorder)
-	span := tracer.StartTrace("my-trace")
+	span := tracer.StartSpan("my-trace")
 	ext.PeerService.Add(span, "my-service")
 	ext.PeerHostname.Add(span, "my-hostname")
 	ext.PeerHostIPv4.Add(span, uint32(127<<24|1))

--- a/globaltracer.go
+++ b/globaltracer.go
@@ -7,8 +7,8 @@ var (
 // InitGlobalTracer sets the [singleton] opentracing.Tracer returned by
 // GlobalTracer(). Those who use GlobalTracer (rather than directly manage an
 // opentracing.Tracer instance) should call InitGlobalTracer as early as possible in
-// main(), prior to calling the `StartTrace` (etc) global funcs below. Prior to
-// calling `InitGlobalTracer`, any Spans started via the `StartTrace` (etc)
+// main(), prior to calling the `StartSpan` (etc) global funcs below. Prior to
+// calling `InitGlobalTracer`, any Spans started via the `StartSpan` (etc)
 // globals are noops.
 func InitGlobalTracer(tracer Tracer) {
 	globalTracer = tracer
@@ -21,7 +21,7 @@ func GlobalTracer() Tracer {
 	return globalTracer
 }
 
-// StartTrace defers to `Tracer.StartTrace`. See `GlobalTracer()`.
-func StartTrace(operationName string) Span {
-	return globalTracer.StartTrace(operationName)
+// StartSpan defers to `Tracer.StartSpan`. See `GlobalTracer()`.
+func StartSpan(operationName string) Span {
+	return globalTracer.StartSpan(operationName)
 }

--- a/noop.go
+++ b/noop.go
@@ -19,17 +19,17 @@ const (
 )
 
 // noopSpan:
-func (n noopSpan) StartChild(operationName string) Span {
-	return defaultNoopSpan
-}
+func (n noopSpan) StartChild(operationName string) Span                  { return defaultNoopSpan }
 func (n noopSpan) SetTag(key string, value interface{}) Span             { return n }
 func (n noopSpan) Finish()                                               {}
+func (n noopSpan) FinishWithOptions(opts FinishOptions)                  {}
 func (n noopSpan) SetTraceAttribute(key, val string) Span                { return n }
 func (n noopSpan) TraceAttribute(key string) string                      { return emptyString }
 func (n noopSpan) LogEvent(event string)                                 {}
 func (n noopSpan) LogEventWithPayload(event string, payload interface{}) {}
 func (n noopSpan) Log(data LogData)                                      {}
 func (n noopSpan) SetOperationName(operationName string) Span            { return n }
+func (n noopSpan) Tracer() Tracer                                        { return defaultNoopTracer }
 
 // PropagateSpanAsBinary belongs to the Tracer interface.
 func (n NoopTracer) PropagateSpanAsBinary(tcid Span) ([]byte, []byte) {
@@ -59,8 +59,13 @@ func (n NoopTracer) JoinTraceFromText(
 	return defaultNoopSpan, nil
 }
 
-// StartTrace belongs to the Tracer interface.
-func (n NoopTracer) StartTrace(operationName string) Span {
+// StartSpan belongs to the Tracer interface.
+func (n NoopTracer) StartSpan(operationName string) Span {
+	return defaultNoopSpan
+}
+
+// StartSpanWithOptions belongs to the Tracer interface.
+func (n NoopTracer) StartSpanWithOptions(opts StartSpanOptions) Span {
 	return defaultNoopSpan
 }
 

--- a/noop.go
+++ b/noop.go
@@ -19,7 +19,6 @@ const (
 )
 
 // noopSpan:
-func (n noopSpan) StartChild(operationName string) Span                  { return defaultNoopSpan }
 func (n noopSpan) SetTag(key string, value interface{}) Span             { return n }
 func (n noopSpan) Finish()                                               {}
 func (n noopSpan) FinishWithOptions(opts FinishOptions)                  {}

--- a/span.go
+++ b/span.go
@@ -33,7 +33,7 @@ type Span interface {
 	Finish()
 	// FinishWithOptions is like Finish() but with explicit control over
 	// timestamps and log data.
-	FinishWithOptions(opts *FinishOptions)
+	FinishWithOptions(opts FinishOptions)
 
 	// LogEvent() is equivalent to
 	//
@@ -129,10 +129,21 @@ type LogData struct {
 type FinishOptions struct {
 	// FinishTime overrides the Span's finish time, or implicitly becomes
 	// time.Now() if FinishTime.IsZero().
+	//
+	// FinishTime must resolve to a timestamp that's >= the Span's StartTime
+	// (per StartSpanOptions).
 	FinishTime time.Time
 
 	// BulkLogData allows the caller to specify the contents of many Log()
 	// calls with a single slice. May be nil.
+	//
+	// None of the LogData.Timestamp values may be .IsZero() (i.e., they must
+	// be set explicitly). Also, they must be >= the Span's start timestamp and
+	// <= the FinishTime (or time.Now() if FinishTime.IsZero()). Otherwise the
+	// behavior of FinishWithOptions() is undefined.
+	//
+	// If specified, the caller hands off ownership of BulkLogData at
+	// FinishWithOptions() invocation time.
 	BulkLogData []LogData
 }
 

--- a/span.go
+++ b/span.go
@@ -6,15 +6,12 @@ import (
 	"time"
 )
 
-// Span represents an active, un-finished span in the opentracing system.
+// Span represents an active, un-finished span in the OpenTracing system.
 //
-// Spans are created by the Tracer interface and Span.StartChild.
+// Spans are created by the Tracer interface.
 type Span interface {
 	// Sets or changes the operation name.
 	SetOperationName(operationName string) Span
-
-	// Creates and starts a child span.
-	StartChild(operationName string) Span
 
 	// Adds a tag to the span.
 	//
@@ -34,6 +31,9 @@ type Span interface {
 	// Finish() should be the last call made to any span instance, and to do
 	// otherwise leads to undefined behavior.
 	Finish()
+	// FinishWithOptions is like Finish() but with explicit control over
+	// timestamps and log data.
+	FinishWithOptions(opts *FinishOptions)
 
 	// LogEvent() is equivalent to
 	//
@@ -86,6 +86,9 @@ type Span interface {
 	//
 	// See the `SetTraceAttribute` notes about `restrictedKey`.
 	TraceAttribute(restrictedKey string) string
+
+	// Provides access to the Tracer that created this Span.
+	Tracer() Tracer
 }
 
 // LogData is data associated to a Span. Every LogData instance should specify
@@ -121,6 +124,18 @@ type LogData struct {
 	Payload interface{}
 }
 
+// FinishOptions allows Span.FinishWithOptions callers to override the finish
+// timestamp and provide log data via a bulk interface.
+type FinishOptions struct {
+	// FinishTime overrides the Span's finish time, or implicitly becomes
+	// time.Now() if FinishTime.IsZero().
+	FinishTime time.Time
+
+	// BulkLogData allows the caller to specify the contents of many Log()
+	// calls with a single slice. May be nil.
+	BulkLogData []LogData
+}
+
 // Tags are a generic map from an arbitrary string key to an opaque value type.
 // The underlying tracing system is responsible for interpreting and
 // serializing the values.
@@ -144,4 +159,12 @@ func CanonicalizeTraceAttributeKey(key string) (string, bool) {
 		return "", false
 	}
 	return strings.ToLower(key), true
+}
+
+// StartChildSpan is a simple helper to start a child span given only its parent (per StartSpanOptions.Parent) and an operation name per Span.SetOperationName.
+func StartChildSpan(parent Span, operationName string) Span {
+	return parent.Tracer.StartSpanWithOptions(SpanOptions{
+		OperationName: operationName,
+		Parent:        parent,
+	})
 }

--- a/span.go
+++ b/span.go
@@ -144,7 +144,7 @@ type FinishOptions struct {
 	//
 	// If specified, the caller hands off ownership of BulkLogData at
 	// FinishWithOptions() invocation time.
-	BulkLogData []LogData
+	BulkLogData []*LogData
 }
 
 // Tags are a generic map from an arbitrary string key to an opaque value type.
@@ -174,7 +174,7 @@ func CanonicalizeTraceAttributeKey(key string) (string, bool) {
 
 // StartChildSpan is a simple helper to start a child span given only its parent (per StartSpanOptions.Parent) and an operation name per Span.SetOperationName.
 func StartChildSpan(parent Span, operationName string) Span {
-	return parent.Tracer.StartSpanWithOptions(SpanOptions{
+	return parent.Tracer().StartSpanWithOptions(StartSpanOptions{
 		OperationName: operationName,
 		Parent:        parent,
 	})

--- a/standardtracer/span.go
+++ b/standardtracer/span.go
@@ -17,13 +17,6 @@ type spanImpl struct {
 	raw      RawSpan
 }
 
-func (s *spanImpl) StartChild(operationName string) opentracing.Span {
-	return s.tracer.StartSpanWithOptions(opentracing.StartSpanOptions{
-		OperationName: operationName,
-		Parent:        s,
-	})
-}
-
 func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/standardtracer/spanpropagator_test.go
+++ b/standardtracer/spanpropagator_test.go
@@ -16,7 +16,7 @@ func TestSpanPropagator(t *testing.T) {
 	recorder := testutils.NewInMemoryRecorder()
 	tracer := standardtracer.New(recorder)
 
-	sp := tracer.StartTrace(op)
+	sp := tracer.StartSpan(op)
 	sp.SetTraceAttribute("foo", "bar")
 
 	textCtx, textAttrs := tracer.PropagateSpanAsText(sp)

--- a/tracer.go
+++ b/tracer.go
@@ -27,7 +27,7 @@ type Tracer interface {
 	//     })
 	//
 	StartSpan(operationName string) Span
-	StartSpanWithOptions(opts SpanOptions) Span
+	StartSpanWithOptions(opts StartSpanOptions) Span
 }
 
 // StartSpanOptions allows Tracer.StartSpanWithOptions callers to override the

--- a/tracer.go
+++ b/tracer.go
@@ -27,7 +27,7 @@ type Tracer interface {
 	//     })
 	//
 	StartSpan(operationName string) Span
-	StartSpanWithOptions(opts *SpanOptions) Span
+	StartSpanWithOptions(opts SpanOptions) Span
 }
 
 // StartSpanOptions allows Tracer.StartSpanWithOptions callers to override the
@@ -38,14 +38,19 @@ type StartSpanOptions struct {
 	OperationName string
 
 	// Parent may specify Span instance that caused the new (child) Span to be
-	// created. May be nil.
+	// created.
+	//
+	// If nil, start a "root" span (i.e., start a new trace).
 	Parent Span
 
 	// StartTime overrides the Span's start time, or implicitly becomes
 	// time.Now() if StartTime.IsZero().
 	StartTime time.Time
 
-	// Zero or more Tags. The restrictions on map values are identical to those
-	// for Span.SetTag(). May be nil.
+	// Tags may have zero or more entries; the restrictions on map values are
+	// identical to those for Span.SetTag(). May be nil.
+	//
+	// If specified, the caller hands off ownership of Tags at
+	// StartSpanWithOptions() invocation time.
 	Tags map[string]interface{}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -1,5 +1,7 @@
 package opentracing
 
+import "time"
+
 // Tracer is a simple, thin interface for Span creation.
 //
 // A straightforward implementation is available via the
@@ -14,13 +16,36 @@ type Tracer interface {
 	//
 	// Examples:
 	//
-	//     var tracer Tracer = ...
+	//     var tracer opentracing.Tracer = ...
 	//
-	//     sp := tracer.StartTrace("GetFeed")
+	//     sp := tracer.StartSpan("GetFeed")
 	//
-	//     sp := tracer.StartTrace("HandleHTTPRequest").
-	//         SetTag("user_agent", req.UserAgent).
-	//         SetTag("lucky_number", 42)
+	//     sp := tracer.StartSpanWithOptions(opentracing.SpanOptions{
+	//         OperationName: "LoggedHTTPRequest",
+	//         Tags: opentracing.Tags{"user_agent", loggedReq.UserAgent},
+	//         StartTime: loggedReq.Timestamp,
+	//     })
 	//
-	StartTrace(operationName string) Span
+	StartSpan(operationName string) Span
+	StartSpanWithOptions(opts *SpanOptions) Span
+}
+
+// StartSpanOptions allows Tracer.StartSpanWithOptions callers to override the
+// start timestamp, specify a parent Span, and make sure that Tags are
+// available at Span initialization time.
+type StartSpanOptions struct {
+	// OperationName may be empty (and set later via Span.SetOperationName)
+	OperationName string
+
+	// Parent may specify Span instance that caused the new (child) Span to be
+	// created. May be nil.
+	Parent Span
+
+	// StartTime overrides the Span's start time, or implicitly becomes
+	// time.Now() if StartTime.IsZero().
+	StartTime time.Time
+
+	// Zero or more Tags. The restrictions on map values are identical to those
+	// for Span.SetTag(). May be nil.
+	Tags map[string]interface{}
 }


### PR DESCRIPTION
While we're at it, add support for Span start/finish options.

@yurishkuro I am amused by the similarity between the Start/FinishOptions and some RFC Go code you sent out in the early days of the DCP discussion late last year. I didn't actually reference it, but if memory serves this is similar.

See also:
- https://github.com/opentracing/opentracing.github.io/issues/44#issuecomment-179654948
- https://github.com/opentracing/opentracing.github.io/issues/22
- https://github.com/opentracing/opentracing.github.io/issues/20, which is basically a dup of 22 just above
- https://github.com/opentracing/opentracing.github.io/issues/43 (perhaps the start options could accomplish this via an explicit Tag)

