### PR TITLE
Import opentracing-go as opentracing

### DIFF
--- a/standardtracer/propagation.go
+++ b/standardtracer/propagation.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 type splitTextPropagator struct {

--- a/standardtracer/propagation_test.go
+++ b/standardtracer/propagation_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/standardtracer"
 	"github.com/opentracing/opentracing-go/testutils"
 )

--- a/standardtracer/raw.go
+++ b/standardtracer/raw.go
@@ -3,7 +3,7 @@ package standardtracer
 import (
 	"time"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // RawSpan encapsulates all state associated with a (finished) Span.

--- a/standardtracer/span.go
+++ b/standardtracer/span.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // Implements the `Span` interface. Created via tracerImpl (see

--- a/standardtracer/tracer.go
+++ b/standardtracer/tracer.go
@@ -3,7 +3,7 @@ package standardtracer
 import (
 	"time"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // New creates and returns a standard Tracer which defers to `recorder` after


### PR DESCRIPTION
The implicit import name makes resolution easier for
tools like `godef`, which at the time of writing do
not have the capability to resolve nonstandard
import paths, for example see

    https://github.com/rogpeppe/godef/issues/18

I looked into adding it for `godef`, but it did not
seem trivial.