### PR TITLE
Avoid allocations, fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+go:
+  - 1.5
+  - tip
+
 install:
   - go get -d -t github.com/opentracing/opentracing-go/...
   - go get -u github.com/golang/lint/...

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 lint:
 	golint ./...
 	@# Run again with magic to exit non-zero if golint outputs anything.
-	@! (golint ./... | read)
+	@! (golint ./... | read dummy)
 
 .PHONY: vet
 vet:

--- a/examples/dapperish/trivialrecorder.go
+++ b/examples/dapperish/trivialrecorder.go
@@ -31,7 +31,7 @@ func (t *TrivialRecorder) SetTag(key string, val interface{}) *TrivialRecorder {
 }
 
 // RecordSpan complies with the standardtracer.Recorder interface.
-func (t *TrivialRecorder) RecordSpan(span *standardtracer.RawSpan) {
+func (t *TrivialRecorder) RecordSpan(span standardtracer.RawSpan) {
 	fmt.Printf(
 		"RecordSpan: %v[%v, %v us] --> %v logs. std context: %v\n",
 		span.Operation, span.Start, span.Duration, len(span.Logs),

--- a/noop.go
+++ b/noop.go
@@ -57,5 +57,5 @@ func (n noopInjectorExtractor) InjectSpan(span Span, carrier interface{}) error 
 }
 
 func (n noopInjectorExtractor) JoinTrace(operationName string, carrier interface{}) (Span, error) {
-	return nil, TraceNotFound
+	return nil, ErrTraceNotFound
 }

--- a/propagation.go
+++ b/propagation.go
@@ -7,19 +7,19 @@ import "errors"
 ///////////////////////////////////////////////////////////////////////////////
 
 var (
-	// TraceNotFound occurs when the `carrier` passed to Extractor.JoinTrace()
+	// ErrTraceNotFound occurs when the `carrier` passed to Extractor.JoinTrace()
 	// is valid and uncorrupted but has insufficient information to join or
 	// resume a trace.
-	TraceNotFound = errors.New("opentracing: Trace not found in Extraction carrier")
+	ErrTraceNotFound = errors.New("opentracing: Trace not found in Extraction carrier")
 
-	// InvalidCarrier errors occur when Injector.InjectSpan() or
+	// ErrInvalidCarrier errors occur when Injector.InjectSpan() or
 	// Extractor.JoinTrace() implementations expect a different type of
 	// `carrier` than they are given.
-	InvalidCarrier = errors.New("opentracing: Invalid Injection/Extraction carrier")
+	ErrInvalidCarrier = errors.New("opentracing: Invalid Injection/Extraction carrier")
 
-	// TraceCorrupted occurs when the `carrier` passed to Extractor.JoinTrace()
+	// ErrTraceCorrupted occurs when the `carrier` passed to Extractor.JoinTrace()
 	// is of the expected type but is corrupted.
-	TraceCorrupted = errors.New("opentracing: Trace data corrupted in Extraction carrier")
+	ErrTraceCorrupted = errors.New("opentracing: Trace data corrupted in Extraction carrier")
 )
 
 // Injector is responsible for injecting Span instances in a manner suitable
@@ -102,6 +102,7 @@ type SplitTextCarrier struct {
 	TraceAttributes map[string]string
 }
 
+// NewSplitTextCarrier creates a new SplitTextCarrier.
 func NewSplitTextCarrier() *SplitTextCarrier {
 	return &SplitTextCarrier{
 		TracerState:     make(map[string]string),
@@ -125,6 +126,7 @@ type SplitBinaryCarrier struct {
 	TraceAttributes []byte
 }
 
+// NewSplitBinaryCarrier creates a new SplitTextCarrier.
 func NewSplitBinaryCarrier() *SplitBinaryCarrier {
 	return &SplitBinaryCarrier{
 		TracerState:     []byte{},

--- a/span.go
+++ b/span.go
@@ -146,7 +146,7 @@ type FinishOptions struct {
 	//
 	// If specified, the caller hands off ownership of BulkLogData at
 	// FinishWithOptions() invocation time.
-	BulkLogData []*LogData
+	BulkLogData []LogData
 }
 
 // Tags are a generic map from an arbitrary string key to an opaque value type.

--- a/standardtracer/bench_test.go
+++ b/standardtracer/bench_test.go
@@ -1,0 +1,65 @@
+package standardtracer
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+var tags []string
+
+func init() {
+	tags = make([]string, 1000)
+	for j := 0; j < len(tags); j++ {
+		tags[j] = fmt.Sprintf("%d", randomID())
+	}
+}
+
+type countingRecorder int32
+
+func (c *countingRecorder) RecordSpan(r RawSpan) {
+	atomic.AddInt32((*int32)(c), 1)
+}
+
+func benchmarkWithOps(b *testing.B, numEvent, numTag, numAttr int) {
+	var r countingRecorder
+	t := New(&r)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sp := t.StartSpan("test")
+		for j := 0; j < numEvent; j++ {
+			sp.LogEvent("event")
+		}
+		for j := 0; j < numTag; j++ {
+			sp.SetTag(tags[j], nil)
+		}
+		for j := 0; j < numAttr; j++ {
+			sp.SetTraceAttribute(tags[j], tags[j])
+		}
+		sp.Finish()
+	}
+	b.StopTimer()
+	if int(r) != b.N {
+		b.Fatalf("missing traces: expected %d, got %d", b.N, r)
+	}
+}
+
+func BenchmarkSpan_Empty(b *testing.B) {
+	benchmarkWithOps(b, 0, 0, 0)
+}
+
+func BenchmarkSpan_100Events(b *testing.B) {
+	benchmarkWithOps(b, 100, 0, 0)
+}
+
+func BenchmarkSpan_1000Events(b *testing.B) {
+	benchmarkWithOps(b, 100, 0, 0)
+}
+
+func BenchmarkSpan_100Tags(b *testing.B) {
+	benchmarkWithOps(b, 0, 100, 0)
+}
+
+func BenchmarkSpan_1000Tags(b *testing.B) {
+	benchmarkWithOps(b, 0, 100, 0)
+}

--- a/standardtracer/propagation.go
+++ b/standardtracer/propagation.go
@@ -92,17 +92,17 @@ func (p *splitTextPropagator) JoinTrace(
 		return nil, fmt.Errorf("Only found %v of 3 required fields", requiredFieldCount)
 	}
 
-	sp := &spanImpl{
-		raw: RawSpan{
-			StandardContext: StandardContext{
-				TraceID:      traceID,
-				SpanID:       randomID(),
-				ParentSpanID: propagatedSpanID,
-				Sampled:      sampled,
-			},
+	sp := p.tracer.getSpan()
+	sp.raw = RawSpan{
+		StandardContext: StandardContext{
+			TraceID:      traceID,
+			SpanID:       randomID(),
+			ParentSpanID: propagatedSpanID,
+			Sampled:      sampled,
 		},
-		traceAttrs: splitTextCarrier.TraceAttributes,
 	}
+	sp.traceAttrs = splitTextCarrier.TraceAttributes
+
 	return p.tracer.startSpanInternal(
 		sp,
 		operationName,
@@ -225,17 +225,16 @@ func (p *splitBinaryPropagator) JoinTrace(
 		attrMap[string(keyBytes)] = string(valBytes)
 	}
 
-	sp := &spanImpl{
-		raw: RawSpan{
-			StandardContext: StandardContext{
-				TraceID:      traceID,
-				SpanID:       randomID(),
-				ParentSpanID: propagatedSpanID,
-				Sampled:      sampledByte != 0,
-			},
+	sp := p.tracer.getSpan()
+	sp.raw = RawSpan{
+		StandardContext: StandardContext{
+			TraceID:      traceID,
+			SpanID:       randomID(),
+			ParentSpanID: propagatedSpanID,
+			Sampled:      sampledByte != 0,
 		},
-		traceAttrs: attrMap,
 	}
+	sp.traceAttrs = attrMap
 
 	return p.tracer.startSpanInternal(
 		sp,

--- a/standardtracer/propagation.go
+++ b/standardtracer/propagation.go
@@ -33,22 +33,22 @@ func (p *splitTextPropagator) InjectSpan(
 	sp opentracing.Span,
 	carrier interface{},
 ) error {
-	sc := sp.(*spanImpl).raw.StandardContext
+	sc := sp.(*spanImpl)
 	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
 	if !ok {
-		return opentracing.InvalidCarrier
+		return opentracing.ErrInvalidCarrier
 	}
 	splitTextCarrier.TracerState = map[string]string{
-		fieldNameTraceID: strconv.FormatInt(sc.TraceID, 10),
-		fieldNameSpanID:  strconv.FormatInt(sc.SpanID, 10),
-		fieldNameSampled: strconv.FormatBool(sc.Sampled),
+		fieldNameTraceID: strconv.FormatInt(sc.raw.TraceID, 10),
+		fieldNameSpanID:  strconv.FormatInt(sc.raw.SpanID, 10),
+		fieldNameSampled: strconv.FormatBool(sc.raw.Sampled),
 	}
-	sc.attrMu.RLock()
+	sc.Lock()
 	splitTextCarrier.TraceAttributes = make(map[string]string, len(sc.traceAttrs))
 	for k, v := range sc.traceAttrs {
 		splitTextCarrier.TraceAttributes[k] = v
 	}
-	sc.attrMu.RUnlock()
+	sc.Unlock()
 	return nil
 }
 
@@ -58,7 +58,7 @@ func (p *splitTextPropagator) JoinTrace(
 ) (opentracing.Span, error) {
 	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
 	if !ok {
-		return nil, opentracing.InvalidCarrier
+		return nil, opentracing.ErrInvalidCarrier
 	}
 	requiredFieldCount := 0
 	var traceID, propagatedSpanID int64
@@ -69,19 +69,19 @@ func (p *splitTextPropagator) JoinTrace(
 		case fieldNameTraceID:
 			traceID, err = strconv.ParseInt(v, 10, 64)
 			if err != nil {
-				return nil, opentracing.TraceCorrupted
+				return nil, opentracing.ErrTraceCorrupted
 			}
 			requiredFieldCount++
 		case fieldNameSpanID:
 			propagatedSpanID, err = strconv.ParseInt(v, 10, 64)
 			if err != nil {
-				return nil, opentracing.TraceCorrupted
+				return nil, opentracing.ErrTraceCorrupted
 			}
 			requiredFieldCount++
 		case fieldNameSampled:
 			sampled, err = strconv.ParseBool(v)
 			if err != nil {
-				return nil, opentracing.TraceCorrupted
+				return nil, opentracing.ErrTraceCorrupted
 			}
 			requiredFieldCount++
 		default:
@@ -92,17 +92,22 @@ func (p *splitTextPropagator) JoinTrace(
 		return nil, fmt.Errorf("Only found %v of 3 required fields", requiredFieldCount)
 	}
 
-	return p.tracer.startSpanInternal(
-		&StandardContext{
-			TraceID:      traceID,
-			SpanID:       randomID(),
-			ParentSpanID: propagatedSpanID,
-			Sampled:      sampled,
-			traceAttrs:   splitTextCarrier.TraceAttributes,
+	sp := &spanImpl{
+		raw: RawSpan{
+			StandardContext: StandardContext{
+				TraceID:      traceID,
+				SpanID:       randomID(),
+				ParentSpanID: propagatedSpanID,
+				Sampled:      sampled,
+			},
 		},
+		traceAttrs: splitTextCarrier.TraceAttributes,
+	}
+	return p.tracer.startSpanInternal(
+		sp,
 		operationName,
 		time.Now(),
-		opentracing.Tags{},
+		nil,
 	), nil
 }
 
@@ -110,25 +115,25 @@ func (p *splitBinaryPropagator) InjectSpan(
 	sp opentracing.Span,
 	carrier interface{},
 ) error {
-	sc := sp.(*spanImpl).raw.StandardContext
+	sc := sp.(*spanImpl)
 	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
 	if !ok {
-		return opentracing.InvalidCarrier
+		return opentracing.ErrInvalidCarrier
 	}
 	var err error
 	var sampledByte byte
-	if sc.Sampled {
+	if sc.raw.Sampled {
 		sampledByte = 1
 	}
 
 	// Handle the trace and span ids, and sampled status.
 	contextBuf := new(bytes.Buffer)
-	err = binary.Write(contextBuf, binary.BigEndian, sc.TraceID)
+	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.TraceID)
 	if err != nil {
 		return err
 	}
 
-	err = binary.Write(contextBuf, binary.BigEndian, sc.SpanID)
+	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.SpanID)
 	if err != nil {
 		return err
 	}
@@ -165,7 +170,7 @@ func (p *splitBinaryPropagator) JoinTrace(
 	var err error
 	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
 	if !ok {
-		return nil, opentracing.InvalidCarrier
+		return nil, opentracing.ErrInvalidCarrier
 	}
 	// Handle the trace, span ids, and sampled status.
 	contextReader := bytes.NewReader(splitBinaryCarrier.TracerState)
@@ -174,15 +179,15 @@ func (p *splitBinaryPropagator) JoinTrace(
 
 	err = binary.Read(contextReader, binary.BigEndian, &traceID)
 	if err != nil {
-		return nil, opentracing.TraceCorrupted
+		return nil, opentracing.ErrTraceCorrupted
 	}
 	err = binary.Read(contextReader, binary.BigEndian, &propagatedSpanID)
 	if err != nil {
-		return nil, opentracing.TraceCorrupted
+		return nil, opentracing.ErrTraceCorrupted
 	}
 	err = binary.Read(contextReader, binary.BigEndian, &sampledByte)
 	if err != nil {
-		return nil, opentracing.TraceCorrupted
+		return nil, opentracing.ErrTraceCorrupted
 	}
 
 	// Handle the attributes.
@@ -190,7 +195,7 @@ func (p *splitBinaryPropagator) JoinTrace(
 	var numAttrs int32
 	err = binary.Read(attrsReader, binary.BigEndian, &numAttrs)
 	if err != nil {
-		return nil, opentracing.TraceCorrupted
+		return nil, opentracing.ErrTraceCorrupted
 	}
 	iNumAttrs := int(numAttrs)
 	attrMap := make(map[string]string, iNumAttrs)
@@ -198,39 +203,45 @@ func (p *splitBinaryPropagator) JoinTrace(
 		var keyLen int32
 		err = binary.Read(attrsReader, binary.BigEndian, &keyLen)
 		if err != nil {
-			return nil, opentracing.TraceCorrupted
+			return nil, opentracing.ErrTraceCorrupted
 		}
 		keyBytes := make([]byte, keyLen)
 		err = binary.Read(attrsReader, binary.BigEndian, &keyBytes)
 		if err != nil {
-			return nil, opentracing.TraceCorrupted
+			return nil, opentracing.ErrTraceCorrupted
 		}
 
 		var valLen int32
 		err = binary.Read(attrsReader, binary.BigEndian, &valLen)
 		if err != nil {
-			return nil, opentracing.TraceCorrupted
+			return nil, opentracing.ErrTraceCorrupted
 		}
 		valBytes := make([]byte, valLen)
 		err = binary.Read(attrsReader, binary.BigEndian, &valBytes)
 		if err != nil {
-			return nil, opentracing.TraceCorrupted
+			return nil, opentracing.ErrTraceCorrupted
 		}
 
 		attrMap[string(keyBytes)] = string(valBytes)
 	}
 
-	return p.tracer.startSpanInternal(
-		&StandardContext{
-			TraceID:      traceID,
-			SpanID:       randomID(),
-			ParentSpanID: propagatedSpanID,
-			Sampled:      sampledByte != 0,
-			traceAttrs:   attrMap,
+	sp := &spanImpl{
+		raw: RawSpan{
+			StandardContext: StandardContext{
+				TraceID:      traceID,
+				SpanID:       randomID(),
+				ParentSpanID: propagatedSpanID,
+				Sampled:      sampledByte != 0,
+			},
 		},
+		traceAttrs: attrMap,
+	}
+
+	return p.tracer.startSpanInternal(
+		sp,
 		operationName,
 		time.Now(),
-		opentracing.Tags{},
+		nil,
 	), nil
 }
 
@@ -267,19 +278,19 @@ func (p *goHTTPPropagator) JoinTrace(
 	header := carrier.(http.Header)
 	tracerStateBase64, found := header[http.CanonicalHeaderKey(tracerStateHeaderName)]
 	if !found || len(tracerStateBase64) == 0 {
-		return nil, opentracing.TraceNotFound
+		return nil, opentracing.ErrTraceNotFound
 	}
 	traceAttrsBase64, found := header[http.CanonicalHeaderKey(traceAttrsHeaderName)]
 	if !found || len(traceAttrsBase64) == 0 {
-		return nil, opentracing.TraceNotFound
+		return nil, opentracing.ErrTraceNotFound
 	}
 	tracerStateBinary, err := base64.StdEncoding.DecodeString(tracerStateBase64[0])
 	if err != nil {
-		return nil, opentracing.TraceCorrupted
+		return nil, opentracing.ErrTraceCorrupted
 	}
 	traceAttrsBinary, err := base64.StdEncoding.DecodeString(traceAttrsBase64[0])
 	if err != nil {
-		return nil, opentracing.TraceCorrupted
+		return nil, opentracing.ErrTraceCorrupted
 	}
 
 	// Defer to SplitBinary for the real work.

--- a/standardtracer/propagation.go
+++ b/standardtracer/propagation.go
@@ -44,8 +44,8 @@ func (p *splitTextPropagator) InjectSpan(
 		fieldNameSampled: strconv.FormatBool(sc.raw.Sampled),
 	}
 	sc.Lock()
-	splitTextCarrier.TraceAttributes = make(map[string]string, len(sc.traceAttrs))
-	for k, v := range sc.traceAttrs {
+	splitTextCarrier.TraceAttributes = make(map[string]string, len(sc.raw.Attributes))
+	for k, v := range sc.raw.Attributes {
 		splitTextCarrier.TraceAttributes[k] = v
 	}
 	sc.Unlock()
@@ -101,7 +101,7 @@ func (p *splitTextPropagator) JoinTrace(
 			Sampled:      sampled,
 		},
 	}
-	sp.traceAttrs = splitTextCarrier.TraceAttributes
+	sp.raw.Attributes = splitTextCarrier.TraceAttributes
 
 	return p.tracer.startSpanInternal(
 		sp,
@@ -145,11 +145,11 @@ func (p *splitBinaryPropagator) InjectSpan(
 
 	// Handle the attributes.
 	attrsBuf := new(bytes.Buffer)
-	err = binary.Write(attrsBuf, binary.BigEndian, int32(len(sc.traceAttrs)))
+	err = binary.Write(attrsBuf, binary.BigEndian, int32(len(sc.raw.Attributes)))
 	if err != nil {
 		return err
 	}
-	for k, v := range sc.traceAttrs {
+	for k, v := range sc.raw.Attributes {
 		keyBytes := []byte(k)
 		err = binary.Write(attrsBuf, binary.BigEndian, int32(len(keyBytes)))
 		err = binary.Write(attrsBuf, binary.BigEndian, keyBytes)
@@ -234,7 +234,7 @@ func (p *splitBinaryPropagator) JoinTrace(
 			Sampled:      sampledByte != 0,
 		},
 	}
-	sp.traceAttrs = attrMap
+	sp.raw.Attributes = attrMap
 
 	return p.tracer.startSpanInternal(
 		sp,

--- a/standardtracer/raw.go
+++ b/standardtracer/raw.go
@@ -10,7 +10,7 @@ import (
 type RawSpan struct {
 	// The RawSpan embeds its StandardContext. Those recording the RawSpan
 	// should also record the contents of its StandardContext.
-	*StandardContext
+	StandardContext
 
 	// The name of the "operation" this span is an instance of. (Called a "span
 	// name" in some implementations)
@@ -26,5 +26,5 @@ type RawSpan struct {
 	Tags opentracing.Tags
 
 	// The span's "microlog".
-	Logs []*opentracing.LogData
+	Logs []opentracing.LogData
 }

--- a/standardtracer/raw.go
+++ b/standardtracer/raw.go
@@ -27,4 +27,7 @@ type RawSpan struct {
 
 	// The span's "microlog".
 	Logs []opentracing.LogData
+
+	// The span's associated attributes.
+	Attributes map[string]string // initialized on first use
 }

--- a/standardtracer/recorder.go
+++ b/standardtracer/recorder.go
@@ -5,5 +5,5 @@ package standardtracer
 // the containing process and provides access to a straightforward tag map.
 type SpanRecorder interface {
 	// Implementations must determine whether and where to store `span`.
-	RecordSpan(span *RawSpan)
+	RecordSpan(span RawSpan)
 }

--- a/standardtracer/span.go
+++ b/standardtracer/span.go
@@ -19,6 +19,12 @@ type spanImpl struct {
 	traceAttrs map[string]string // initialized on first use
 }
 
+func (s *spanImpl) reset() {
+	s.tracer = nil
+	s.raw = RawSpan{}
+	s.traceAttrs = nil // TODO(tschottdorf): is clearing out the map better?
+}
+
 func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
 	s.Lock()
 	defer s.Unlock()
@@ -78,6 +84,7 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	}
 	s.raw.Duration = duration
 	s.tracer.recorder.RecordSpan(s.raw)
+	s.tracer.spanPool.Put(s)
 }
 
 func (s *spanImpl) SetTraceAttribute(restrictedKey, val string) opentracing.Span {

--- a/standardtracer/span.go
+++ b/standardtracer/span.go
@@ -11,22 +11,27 @@ import (
 // Implements the `Span` interface. Created via tracerImpl (see
 // `standardtracer.New()`).
 type spanImpl struct {
-	lock     sync.Mutex
-	tracer   *tracerImpl
-	recorder SpanRecorder
-	raw      RawSpan
+	tracer     *tracerImpl
+	sync.Mutex // protects the fields below
+	raw        RawSpan
+	// TODO(tschottdorf): should this be available to the Recorder
+	// via RawSpan as well?
+	traceAttrs map[string]string // initialized on first use
 }
 
 func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.Lock()
+	defer s.Unlock()
 	s.raw.Operation = operationName
 	return s
 }
 
 func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.Lock()
+	defer s.Unlock()
+	if s.raw.Tags == nil {
+		s.raw.Tags = opentracing.Tags{}
+	}
 	s.raw.Tags[key] = value
 	return s
 }
@@ -45,14 +50,14 @@ func (s *spanImpl) LogEventWithPayload(event string, payload interface{}) {
 }
 
 func (s *spanImpl) Log(ld opentracing.LogData) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.Lock()
+	defer s.Unlock()
 
 	if ld.Timestamp.IsZero() {
 		ld.Timestamp = time.Now()
 	}
 
-	s.raw.Logs = append(s.raw.Logs, &ld)
+	s.raw.Logs = append(s.raw.Logs, ld)
 }
 
 func (s *spanImpl) Finish() {
@@ -66,13 +71,13 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	}
 	duration := finishTime.Sub(s.raw.Start)
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.Lock()
+	defer s.Unlock()
 	if opts.BulkLogData != nil {
 		s.raw.Logs = append(s.raw.Logs, opts.BulkLogData...)
 	}
 	s.raw.Duration = duration
-	s.recorder.RecordSpan(&s.raw)
+	s.tracer.recorder.RecordSpan(s.raw)
 }
 
 func (s *spanImpl) SetTraceAttribute(restrictedKey, val string) opentracing.Span {
@@ -81,10 +86,12 @@ func (s *spanImpl) SetTraceAttribute(restrictedKey, val string) opentracing.Span
 		panic(fmt.Errorf("Invalid key: %q", restrictedKey))
 	}
 
-	s.raw.StandardContext.attrMu.Lock()
-	defer s.raw.StandardContext.attrMu.Unlock()
-
-	s.raw.StandardContext.traceAttrs[canonicalKey] = val
+	s.Lock()
+	defer s.Unlock()
+	if s.traceAttrs == nil {
+		s.traceAttrs = make(map[string]string)
+	}
+	s.traceAttrs[canonicalKey] = val
 	return s
 }
 
@@ -94,10 +101,10 @@ func (s *spanImpl) TraceAttribute(restrictedKey string) string {
 		panic(fmt.Errorf("Invalid key: %q", restrictedKey))
 	}
 
-	s.raw.StandardContext.attrMu.RLock()
-	defer s.raw.StandardContext.attrMu.RUnlock()
+	s.Lock()
+	defer s.Unlock()
 
-	return s.raw.StandardContext.traceAttrs[canonicalKey]
+	return s.traceAttrs[canonicalKey]
 }
 
 func (s *spanImpl) Tracer() opentracing.Tracer {

--- a/standardtracer/span.go
+++ b/standardtracer/span.go
@@ -14,15 +14,12 @@ type spanImpl struct {
 	tracer     *tracerImpl
 	sync.Mutex // protects the fields below
 	raw        RawSpan
-	// TODO(tschottdorf): should this be available to the Recorder
-	// via RawSpan as well?
-	traceAttrs map[string]string // initialized on first use
 }
 
 func (s *spanImpl) reset() {
 	s.tracer = nil
 	s.raw = RawSpan{}
-	s.traceAttrs = nil // TODO(tschottdorf): is clearing out the map better?
+	s.raw.Attributes = nil // TODO(tschottdorf): is clearing out the map better?
 }
 
 func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
@@ -95,10 +92,10 @@ func (s *spanImpl) SetTraceAttribute(restrictedKey, val string) opentracing.Span
 
 	s.Lock()
 	defer s.Unlock()
-	if s.traceAttrs == nil {
-		s.traceAttrs = make(map[string]string)
+	if s.raw.Attributes == nil {
+		s.raw.Attributes = make(map[string]string)
 	}
-	s.traceAttrs[canonicalKey] = val
+	s.raw.Attributes[canonicalKey] = val
 	return s
 }
 
@@ -111,7 +108,7 @@ func (s *spanImpl) TraceAttribute(restrictedKey string) string {
 	s.Lock()
 	defer s.Unlock()
 
-	return s.traceAttrs[canonicalKey]
+	return s.raw.Attributes[canonicalKey]
 }
 
 func (s *spanImpl) Tracer() opentracing.Tracer {

--- a/standardtracer/standardcontext.go
+++ b/standardtracer/standardcontext.go
@@ -1,7 +1,5 @@
 package standardtracer
 
-import "sync"
-
 // StandardContext holds the basic Span metadata.
 type StandardContext struct {
 	// A probabilistically unique identifier for a [multi-span] trace.
@@ -15,38 +13,4 @@ type StandardContext struct {
 
 	// Whether the trace is sampled.
 	Sampled bool
-
-	// `tagLock` protects the `traceAttrs` map, which in turn supports
-	// `SetTraceAttribute` and `TraceAttribute`.
-	attrMu     sync.RWMutex
-	traceAttrs map[string]string
-}
-
-// NewRootStandardContext creates a StandardContext corresponding to a root
-// span.
-func NewRootStandardContext() *StandardContext {
-	return &StandardContext{
-		TraceID:    randomID(),
-		SpanID:     randomID(),
-		Sampled:    randomID()%64 == 0,
-		traceAttrs: make(map[string]string),
-	}
-}
-
-// NewChild creates a new child StandardContext.
-func (c *StandardContext) NewChild() *StandardContext {
-	c.attrMu.RLock()
-	newTags := make(map[string]string, len(c.traceAttrs))
-	for k, v := range c.traceAttrs {
-		newTags[k] = v
-	}
-	c.attrMu.RUnlock()
-
-	return &StandardContext{
-		TraceID:      c.TraceID,
-		SpanID:       randomID(),
-		ParentSpanID: c.SpanID,
-		Sampled:      c.Sampled,
-		traceAttrs:   newTags,
-	}
 }

--- a/standardtracer/tracer.go
+++ b/standardtracer/tracer.go
@@ -72,10 +72,10 @@ func (t *tracerImpl) StartSpanWithOptions(
 		sp.raw.Sampled = pr.raw.Sampled
 
 		pr.Lock()
-		if l := len(pr.traceAttrs); l > 0 {
-			sp.traceAttrs = make(map[string]string, len(pr.traceAttrs))
-			for k, v := range pr.traceAttrs {
-				sp.traceAttrs[k] = v
+		if l := len(pr.raw.Attributes); l > 0 {
+			sp.raw.Attributes = make(map[string]string, len(pr.raw.Attributes))
+			for k, v := range pr.raw.Attributes {
+				sp.raw.Attributes[k] = v
 			}
 		}
 		pr.Unlock()

--- a/standardtracer/util.go
+++ b/standardtracer/util.go
@@ -7,13 +7,19 @@ import (
 )
 
 var (
-	seededIDGen  = rand.New(rand.NewSource(time.Now().UnixNano()))
+	seededIDGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+	// The golang rand generators are *not* intrinsically thread-safe.
 	seededIDLock sync.Mutex
 )
 
 func randomID() int64 {
-	// The golang rand generators are *not* intrinsically thread-safe.
 	seededIDLock.Lock()
 	defer seededIDLock.Unlock()
 	return seededIDGen.Int63()
+}
+
+func randomID2() (int64, int64) {
+	seededIDLock.Lock()
+	defer seededIDLock.Unlock()
+	return seededIDGen.Int63(), seededIDGen.Int63()
 }

--- a/testutils/recorder.go
+++ b/testutils/recorder.go
@@ -10,31 +10,31 @@ import (
 // standardtracer.SpanRecorder that stores all reported spans in memory, accessible
 // via reporter.GetSpans()
 type InMemoryRecorder struct {
-	spans []*standardtracer.RawSpan
+	spans []standardtracer.RawSpan
 	lock  sync.Mutex
 }
 
 // NewInMemoryRecorder instantiates a new InMemoryRecorder for testing purposes.
 func NewInMemoryRecorder() *InMemoryRecorder {
 	return &InMemoryRecorder{
-		spans: make([]*standardtracer.RawSpan, 0),
+		spans: make([]standardtracer.RawSpan, 0),
 	}
 }
 
 // RecordSpan implements RecordSpan() of standardtracer.SpanRecorder.
 //
 // The recorded spans can be retrieved via recorder.Spans slice.
-func (recorder *InMemoryRecorder) RecordSpan(span *standardtracer.RawSpan) {
+func (recorder *InMemoryRecorder) RecordSpan(span standardtracer.RawSpan) {
 	recorder.lock.Lock()
 	defer recorder.lock.Unlock()
 	recorder.spans = append(recorder.spans, span)
 }
 
 // GetSpans returns a snapshot of spans recorded so far.
-func (recorder *InMemoryRecorder) GetSpans() []*standardtracer.RawSpan {
+func (recorder *InMemoryRecorder) GetSpans() []standardtracer.RawSpan {
 	recorder.lock.Lock()
 	defer recorder.lock.Unlock()
-	spans := make([]*standardtracer.RawSpan, len(recorder.spans))
+	spans := make([]standardtracer.RawSpan, len(recorder.spans))
 	copy(spans, recorder.spans)
 	return spans
 }

--- a/testutils/recorder_test.go
+++ b/testutils/recorder_test.go
@@ -1,6 +1,7 @@
 package testutils_test
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -11,8 +12,8 @@ import (
 func TestInMemoryRecorderSpans(t *testing.T) {
 	recorder := testutils.NewInMemoryRecorder()
 	var apiRecorder standardtracer.SpanRecorder = recorder
-	span := &standardtracer.RawSpan{
-		StandardContext: &standardtracer.StandardContext{},
+	span := standardtracer.RawSpan{
+		StandardContext: standardtracer.StandardContext{},
 		Operation:       "test-span",
 		Start:           time.Now(),
 		Duration:        -1,
@@ -21,7 +22,7 @@ func TestInMemoryRecorderSpans(t *testing.T) {
 	if len(recorder.GetSpans()) != 1 {
 		t.Fatal("No spans recorded")
 	}
-	if recorder.GetSpans()[0] != span {
+	if !reflect.DeepEqual(recorder.GetSpans()[0], span) {
 		t.Fatal("Span not recorded")
 	}
 }


### PR DESCRIPTION
Embed StandardContext (not *StandardContext) into
RawSpan and initialize the attribute and tags map
only on the first write (it is valid to read from
a nil map).

Move the trace attributes from StandardContext onto
spanImpl; they were not exposed to the recorder, and
the lock on StandardContext required that object to
always be heap allocated. If they need to be exposed
to the user, they can be moved onto RawSpan (or even
back onto StandardContext, but without the lock).
Locking is instead synchronized through the Span's
log.

Work towards sane allocation behavior and add some
benchmarks to that effect: Span creation and destruction
with calls to LogEvent, SetTag oder SetTraceAttribute
now don't allocate.

Changed various other pointers to be passed by-value.

Fix various linter errors and the invocation in
the Makefile (which did not exit nonzero on issues).

Use a sync.Pool instead of new allocations …
This reduces the allocs for a common Span to zero.

```
name               old time/op    new time/op    delta
Span_Empty-8          411ns ± 0%     337ns ± 0%   ~     (p=1.000 n=1+1)
Span_100Events-8     18.2µs ± 0%    18.6µs ± 0%   ~     (p=1.000 n=1+1)
Span_1000Events-8    18.2µs ± 0%    19.3µs ± 0%   ~     (p=1.000 n=1+1)
Span_100Tags-8       25.1µs ± 0%    26.2µs ± 0%   ~     (p=1.000 n=1+1)
Span_1000Tags-8      24.7µs ± 0%    24.9µs ± 0%   ~     (p=1.000 n=1+1)

name               old alloc/op   new alloc/op   delta
Span_Empty-8           144B ± 0%       0B ±NaN%   ~     (p=1.000 n=1+1)
Span_100Events-8     16.2kB ± 0%    16.1kB ± 0%   ~     (p=1.000 n=1+1)
Span_1000Events-8    16.2kB ± 0%    16.1kB ± 0%   ~     (p=1.000 n=1+1)
Span_100Tags-8       10.7kB ± 0%    10.5kB ± 0%   ~     (p=1.000 n=1+1)
Span_1000Tags-8      10.7kB ± 0%    10.5kB ± 0%   ~     (p=1.000 n=1+1)

name               old allocs/op  new allocs/op  delta
Span_Empty-8           1.00 ± 0%     0.00 ±NaN%   ~     (p=1.000 n=1+1)
Span_100Events-8       9.00 ± 0%      8.00 ± 0%   ~     (p=1.000 n=1+1)
Span_1000Events-8      9.00 ± 0%      8.00 ± 0%   ~     (p=1.000 n=1+1)
Span_100Tags-8         12.0 ± 0%      11.0 ± 0%   ~     (p=1.000 n=1+1)
Span_1000Tags-8        12.0 ± 0%      11.0 ± 0%   ~     (p=1.000 n=1+1)
```

FYI, I'm piling more commits on top of this, but would be good to get this
in/discuss it before it gets more refined.