### PR TITLE
Add benchmarks for serialization, and make some improvements

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -91,6 +91,10 @@ const (
 // The Span is separated in this way for a variety of reasons; the most
 // important is to give OpenTracing users a portable way to opt out of Trace
 // Attribute propagation entirely if they deem it a stability risk.
+//
+// It is legal to provide one or both maps as `nil`; they will be created
+// as needed. If non-nil maps are provided, they will be used without
+// clearing them out on injection.
 type SplitTextCarrier struct {
 	// TracerState is Tracer-specific context that must cross process
 	// boundaries. For example, in Dapper this would include a trace_id, a
@@ -104,10 +108,7 @@ type SplitTextCarrier struct {
 
 // NewSplitTextCarrier creates a new SplitTextCarrier.
 func NewSplitTextCarrier() *SplitTextCarrier {
-	return &SplitTextCarrier{
-		TracerState:     make(map[string]string),
-		TraceAttributes: make(map[string]string),
-	}
+	return &SplitTextCarrier{}
 }
 
 // SplitBinaryCarrier breaks a propagated Span into two pieces.
@@ -115,6 +116,9 @@ func NewSplitTextCarrier() *SplitTextCarrier {
 // The Span is separated in this way for a variety of reasons; the most
 // important is to give OpenTracing users a portable way to opt out of Trace
 // Attribute propagation entirely if they deem it a stability risk.
+//
+// Both byte slices may be nil; on injection, what is provided will be cleared
+// and the resulting capacity used.
 type SplitBinaryCarrier struct {
 	// TracerState is Tracer-specific context that must cross process
 	// boundaries. For example, in Dapper this would include a trace_id, a
@@ -128,8 +132,5 @@ type SplitBinaryCarrier struct {
 
 // NewSplitBinaryCarrier creates a new SplitTextCarrier.
 func NewSplitBinaryCarrier() *SplitBinaryCarrier {
-	return &SplitBinaryCarrier{
-		TracerState:     []byte{},
-		TraceAttributes: []byte{},
-	}
+	return &SplitBinaryCarrier{}
 }

--- a/propagation.go
+++ b/propagation.go
@@ -104,7 +104,6 @@ type SplitTextCarrier struct {
 
 // NewSplitTextCarrier creates a new SplitTextCarrier.
 func NewSplitTextCarrier() *SplitTextCarrier {
-	// TODO(tschottdorf): a global sync.Pool can help reduce allocations.
 	return &SplitTextCarrier{
 		TracerState:     make(map[string]string),
 		TraceAttributes: make(map[string]string),

--- a/propagation.go
+++ b/propagation.go
@@ -104,6 +104,7 @@ type SplitTextCarrier struct {
 
 // NewSplitTextCarrier creates a new SplitTextCarrier.
 func NewSplitTextCarrier() *SplitTextCarrier {
+	// TODO(tschottdorf): a global sync.Pool can help reduce allocations.
 	return &SplitTextCarrier{
 		TracerState:     make(map[string]string),
 		TraceAttributes: make(map[string]string),

--- a/standardtracer/bench_test.go
+++ b/standardtracer/bench_test.go
@@ -2,6 +2,7 @@ package standardtracer
 
 import (
 	"fmt"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
@@ -108,6 +109,8 @@ func benchmarkInject(b *testing.B, format opentracing.BuiltinFormat, numAttr int
 		carrier = opentracing.NewSplitTextCarrier()
 	case opentracing.SplitBinary:
 		carrier = opentracing.NewSplitBinaryCarrier()
+	case opentracing.GoHTTPHeader:
+		carrier = http.Header{}
 	default:
 		b.Fatalf("unhandled format %d", format)
 	}
@@ -132,6 +135,8 @@ func benchmarkExtract(b *testing.B, format opentracing.BuiltinFormat, numAttr in
 		carrier = opentracing.NewSplitTextCarrier()
 	case opentracing.SplitBinary:
 		carrier = opentracing.NewSplitBinaryCarrier()
+	case opentracing.GoHTTPHeader:
+		carrier = http.Header{}
 	default:
 		b.Fatalf("unhandled format %d", format)
 	}
@@ -157,6 +162,14 @@ func BenchmarkInject_SplitText_100Attributes(b *testing.B) {
 	benchmarkInject(b, opentracing.SplitText, 100)
 }
 
+func BenchmarkInject_GoHTTPHeader_Empty(b *testing.B) {
+	benchmarkInject(b, opentracing.GoHTTPHeader, 0)
+}
+
+func BenchmarkInject_GoHTTPHeader_100Attributes(b *testing.B) {
+	benchmarkInject(b, opentracing.GoHTTPHeader, 100)
+}
+
 func BenchmarkInject_SplitBinary_Empty(b *testing.B) {
 	benchmarkInject(b, opentracing.SplitBinary, 0)
 }
@@ -171,6 +184,14 @@ func BenchmarkExtract_SplitText_Empty(b *testing.B) {
 
 func BenchmarkExtract_SplitText_100Attributes(b *testing.B) {
 	benchmarkExtract(b, opentracing.SplitText, 100)
+}
+
+func BenchmarkExtract_GoHTTPHeader_Empty(b *testing.B) {
+	benchmarkExtract(b, opentracing.GoHTTPHeader, 0)
+}
+
+func BenchmarkExtract_GoHTTPHeader_100Attributes(b *testing.B) {
+	benchmarkExtract(b, opentracing.GoHTTPHeader, 100)
 }
 
 func BenchmarkExtract_SplitBinary_Empty(b *testing.B) {

--- a/standardtracer/propagation.go
+++ b/standardtracer/propagation.go
@@ -172,7 +172,6 @@ func (p *splitBinaryPropagator) JoinTrace(
 	operationName string,
 	carrier interface{},
 ) (opentracing.Span, error) {
-	var err error
 	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
 	if !ok {
 		return nil, opentracing.ErrInvalidCarrier
@@ -185,24 +184,20 @@ func (p *splitBinaryPropagator) JoinTrace(
 	var traceID, propagatedSpanID int64
 	var sampledByte byte
 
-	err = binary.Read(contextReader, binary.BigEndian, &traceID)
-	if err != nil {
+	if err := binary.Read(contextReader, binary.BigEndian, &traceID); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
-	err = binary.Read(contextReader, binary.BigEndian, &propagatedSpanID)
-	if err != nil {
+	if err := binary.Read(contextReader, binary.BigEndian, &propagatedSpanID); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
-	err = binary.Read(contextReader, binary.BigEndian, &sampledByte)
-	if err != nil {
+	if err := binary.Read(contextReader, binary.BigEndian, &sampledByte); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
 
 	// Handle the attributes.
 	attrsReader := bytes.NewReader(splitBinaryCarrier.TraceAttributes)
 	var numAttrs int32
-	err = binary.Read(attrsReader, binary.BigEndian, &numAttrs)
-	if err != nil {
+	if err := binary.Read(attrsReader, binary.BigEndian, &numAttrs); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
 	iNumAttrs := int(numAttrs)
@@ -212,8 +207,7 @@ func (p *splitBinaryPropagator) JoinTrace(
 		attrMap = make(map[string]string, iNumAttrs)
 		var keyLen, valLen int32
 		for i := 0; i < iNumAttrs; i++ {
-			err = binary.Read(attrsReader, binary.BigEndian, &keyLen)
-			if err != nil {
+			if err := binary.Read(attrsReader, binary.BigEndian, &keyLen); err != nil {
 				return nil, opentracing.ErrTraceCorrupted
 			}
 			buf.Grow(int(keyLen))
@@ -223,8 +217,7 @@ func (p *splitBinaryPropagator) JoinTrace(
 			key := buf.String()
 			buf.Reset()
 
-			err = binary.Read(attrsReader, binary.BigEndian, &valLen)
-			if err != nil {
+			if err := binary.Read(attrsReader, binary.BigEndian, &valLen); err != nil {
 				return nil, opentracing.ErrTraceCorrupted
 			}
 			if n, err := io.CopyN(&buf, attrsReader, int64(valLen)); err != nil || int32(n) != valLen {


### PR DESCRIPTION
Pick some (but not all) low hanging fruit. For example, the encoding
in `github.com/cockroachdb/cockroach/util/encoding` has primitives
better suited to providing an efficient wire encoding.

```
name                                 old time/op    new time/op    delta
Inject_SplitBinary_Empty-8              792ns ± 1%     825ns ± 4%   +4.26%        (p=0.006 n=10+10)
Inject_SplitBinary_100Attributes-8     98.6µs ± 2%    38.0µs ± 2%  -61.48%        (p=0.000 n=10+10)
Extract_SplitBinary_Empty-8             882ns ± 1%     885ns ± 1%     ~            (p=0.287 n=9+10)
Extract_SplitBinary_100Attributes-8     155µs ± 1%      67µs ± 4%  -56.87%        (p=0.000 n=10+10)

name                                 old alloc/op   new alloc/op   delta
Inject_SplitBinary_Empty-8               352B ± 0%      352B ± 0%     ~     (all samples are equal)
Inject_SplitBinary_100Attributes-8     39.9kB ± 0%     6.8kB ± 0%  -83.09%        (p=0.000 n=10+10)
Extract_SplitBinary_Empty-8              224B ± 0%      224B ± 0%     ~     (all samples are equal)
Extract_SplitBinary_100Attributes-8    37.7kB ± 0%    22.5kB ± 0%  -40.38%        (p=0.000 n=10+10)

name                                 old allocs/op  new allocs/op  delta
Inject_SplitBinary_Empty-8               10.0 ± 0%      10.0 ± 0%     ~     (all samples are equal)
Inject_SplitBinary_100Attributes-8      1.22k ± 0%     0.41k ± 0%  -66.28%        (p=0.000 n=10+10)
Extract_SplitBinary_Empty-8              10.0 ± 0%      10.0 ± 0%     ~     (all samples are equal)
Extract_SplitBinary_100Attributes-8     1.21k ± 0%     0.62k ± 0%  -49.09%        (p=0.000 n=10+10)
```