### PR TITLE
Add dynamic configuration

### DIFF
--- a/ext/tags.go
+++ b/ext/tags.go
@@ -22,6 +22,9 @@ var (
 
 	// PeerPort records port number of the peer
 	PeerPort = uint16Tag("peer.port")
+
+	// SamplingPriority determines the priority of sampling this Span.
+	SamplingPriority = uint32Tag("sampling.priority")
 )
 
 type stringTag string

--- a/ext/tags.go
+++ b/ext/tags.go
@@ -1,8 +1,6 @@
 package ext
 
-import (
-	"github.com/opentracing/opentracing-go"
-)
+import opentracing "github.com/opentracing/opentracing-go"
 
 var (
 	// PeerXXX tags can be emitted by either client-side of server-side to describe
@@ -24,7 +22,7 @@ var (
 	PeerPort = uint16Tag("peer.port")
 
 	// SamplingPriority determines the priority of sampling this Span.
-	SamplingPriority = uint32Tag("sampling.priority")
+	SamplingPriority = uint16Tag("sampling.priority")
 )
 
 type stringTag string

--- a/span.go
+++ b/span.go
@@ -167,6 +167,8 @@ var regexTraceAttribute = regexp.MustCompile("^(?i:[a-z0-9][-a-z0-9]*)$")
 
 // CanonicalizeTraceAttributeKey returns the canonicalized version of trace tag
 // key `key`, and true if and only if the key was valid.
+//
+// It is more performant to use lowercase keys only.
 func CanonicalizeTraceAttributeKey(key string) (string, bool) {
 	if !regexTraceAttribute.MatchString(key) {
 		return "", false

--- a/standardtracer/bench_test.go
+++ b/standardtracer/bench_test.go
@@ -80,9 +80,9 @@ func BenchmarkSpan_100Attributes(b *testing.B) {
 func BenchmarkTrimmedSpan_100Events_100Tags_100Attributes(b *testing.B) {
 	var r countingRecorder
 	opts := DefaultOptions()
-	opts.TrimUnsampledSpans(true)
-	opts.ShouldSample(func(_ int64) bool { return false })
-	opts.Recorder(&r)
+	opts.TrimUnsampledSpans = true
+	opts.ShouldSample = func(_ int64) bool { return false }
+	opts.Recorder = &r
 	t := NewWithOptions(opts)
 	benchmarkWithOpsAndCB(b, func() opentracing.Span {
 		sp := t.StartSpan("test")

--- a/standardtracer/span.go
+++ b/standardtracer/span.go
@@ -3,7 +3,6 @@ package standardtracer
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -32,7 +31,7 @@ func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
 }
 
 func (s *spanImpl) trim() bool {
-	return !s.raw.Sampled && atomic.LoadInt32(&s.tracer.trimUnsampledSpans) != 0
+	return !s.raw.Sampled && s.tracer.TrimUnsampledSpans
 }
 
 func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
@@ -98,7 +97,7 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	s.raw.Duration = duration
 	s.Unlock()
 
-	s.tracer.recorder.Load().(SpanRecorder).RecordSpan(s.raw)
+	s.tracer.Recorder.RecordSpan(s.raw)
 	s.tracer.spanPool.Put(s)
 }
 

--- a/standardtracer/span.go
+++ b/standardtracer/span.go
@@ -103,10 +103,6 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 }
 
 func (s *spanImpl) SetTraceAttribute(restrictedKey, val string) opentracing.Span {
-	// TODO(tschottdorf): this is in a bad place performance-wise. Most callers
-	// will have fixed attribute keys, so the are in a much better position to
-	// canonicalize here. Alternatively, we could put a LRU cache here, but that
-	// is more complexity than is warranted for.
 	canonicalKey, valid := opentracing.CanonicalizeTraceAttributeKey(restrictedKey)
 	if !valid {
 		panic(fmt.Errorf("Invalid key: %q", restrictedKey))

--- a/standardtracer/tracer.go
+++ b/standardtracer/tracer.go
@@ -2,16 +2,67 @@ package standardtracer
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-// New creates and returns a standard Tracer which defers to `recorder` after
-// RawSpans have been assembled.
-func New(recorder SpanRecorder) opentracing.Tracer {
+type sampleFunc func(int64) bool
+
+// Options allows creating a customized Tracer via NewWithOptions. The object
+// is thread safe and can be updated freely to influence the behavior of the
+// Tracer.
+type Options struct {
+	shouldSample       atomic.Value // contains a sampleFunc
+	trimUnsampledSpans int32        // updated atomically
+	recorder           atomic.Value // contains a SpanRecorder
+}
+
+// DefaultOptions returns an Options object with a 1 in 64 sampling rate and
+// all options disabled. A Recorder needs to be set manually before using the
+// returned object with a Tracer.
+func DefaultOptions() *Options {
+	opts := &Options{}
+	opts.ShouldSample(func(traceID int64) bool { return traceID%64 == 0 })
+	return opts
+}
+
+// ShouldSample takes a function which is called when creating a new Span and
+// determines whether that Span is sampled. The randomized TraceID is supplied
+// to allow deterministic sampling decisions to be made across different nodes.
+// For example,
+//
+//   func(traceID int64) { return traceID % 64 == 0 }
+//
+// samples every 64th trace on average.
+func (o *Options) ShouldSample(f func(int64) bool) {
+	o.shouldSample.Store(sampleFunc(f))
+}
+
+// Recorder receives Spans which have been finished.
+func (o *Options) Recorder(recorder SpanRecorder) {
+	o.recorder.Store(recorder)
+}
+
+// TrimUnsampledSpans turns potentially expensive operations on unsampled
+// Spans into no-ops. More precisely, tags, attributes and log events
+// are silently discarded.
+func (o *Options) TrimUnsampledSpans(b bool) {
+	var i int32
+	if b {
+		i = 1
+	}
+	atomic.StoreInt32(&o.trimUnsampledSpans, i)
+}
+
+// NewWithOptions creates a customized Tracer.
+func NewWithOptions(opts *Options) opentracing.Tracer {
+	if opts == nil {
+		panic("nil Options passed to NewWithOptions")
+	}
 	rval := &tracerImpl{
-		recorder: recorder,
+		Options: opts,
 		spanPool: sync.Pool{New: func() interface{} {
 			return &spanImpl{}
 		}},
@@ -22,10 +73,21 @@ func New(recorder SpanRecorder) opentracing.Tracer {
 	return rval
 }
 
+// New creates and returns a standard Tracer which defers completed Spans to
+// `recorder`.
+// Spans created by this Tracer support the ext.SamplingPriority tag: Calling
+// SetTag(ext.SamplingPriority, nil) causes the Span to be Sampled from that
+// point on.
+func New(recorder SpanRecorder) opentracing.Tracer {
+	opts := DefaultOptions()
+	opts.Recorder(recorder)
+	return NewWithOptions(opts)
+}
+
 // Implements the `Tracer` interface.
 type tracerImpl struct {
+	*Options
 	spanPool         sync.Pool
-	recorder         SpanRecorder
 	textPropagator   *splitTextPropagator
 	binaryPropagator *splitBinaryPropagator
 	goHTTPPropagator *goHTTPPropagator
@@ -63,7 +125,7 @@ func (t *tracerImpl) StartSpanWithOptions(
 	sp := t.getSpan()
 	if opts.Parent == nil {
 		sp.raw.TraceID, sp.raw.SpanID = randomID2()
-		sp.raw.Sampled = sp.raw.TraceID%64 == 0
+		sp.raw.Sampled = t.shouldSample.Load().(sampleFunc)(sp.raw.TraceID)
 	} else {
 		pr := opts.Parent.(*spanImpl)
 		sp.raw.TraceID = pr.raw.TraceID

--- a/standardtracer/tracer.go
+++ b/standardtracer/tracer.go
@@ -52,9 +52,8 @@ func NewWithOptions(opts Options) opentracing.Tracer {
 
 // New creates and returns a standard Tracer which defers completed Spans to
 // `recorder`.
-// Spans created by this Tracer support the ext.SamplingPriority tag: Calling
-// SetTag(ext.SamplingPriority, nil) causes the Span to be Sampled from that
-// point on.
+// Spans created by this Tracer support the ext.SamplingPriority tag: Setting
+// ext.SamplingPriority causes the Span to be Sampled from that point on.
 func New(recorder SpanRecorder) opentracing.Tracer {
 	opts := DefaultOptions()
 	opts.Recorder = recorder


### PR DESCRIPTION
Introduce the Options type and corresponding Tracer
constructor NewWithOptions.
Options currently include a user-provided sample
function (i.e. a mapping from TraceID to boolean),
the SpanRecorder, and the option to ignore logs,
attributes and tags (except ext.SamplingPriority)
on non-sampled Spans for performance.

Support ext.SamplingPriority in standardtracer.

This needs a few unit tests, but I wanted to get into
the discussion first. The motivation for this change is
wanting to use `standardtracer` in [cockroachdb/cockroach](https://github.com/cockroachdb/cockroach);
these are some basic changes which make relevant
functionality available.

Added benchmark which demonstrates that a `trimmed` Span behaves
effectively like a no-op span, except that there will still be serialization overhead.
This can be avoided a) by better optimization of serialization and b)
by checking for the SamplingPriority tag before calls to the injector
(if serialization is to be avoided entirely).

```
BenchmarkTrimmedSpan_100Events_100Tags_100Attributes-8	   50000	     33144 ns/op	       0 B/op	       0 allocs/op
```