### PR TITLE
Change common tags to use Set instead of Add method. Add Span Kind.

### DIFF
--- a/ext/tags.go
+++ b/ext/tags.go
@@ -2,6 +2,17 @@ package ext
 
 import opentracing "github.com/opentracing/opentracing-go"
 
+// These constants define common tag names recommended for better portability across
+// tracing systems and languages/platforms.
+//
+// The tag names are defined as typed strings, so that in addition to the usual use
+//
+//     span.setTag(TagName, value)
+//
+// they also support value type validation via this additional syntax:
+//
+//    TagName.Set(span, value)
+//
 var (
 	// PeerXXX tags can be emitted by either client-side of server-side to describe
 	// the other side/service in a peer-to-peer communications, like an RPC call.

--- a/ext/tags.go
+++ b/ext/tags.go
@@ -23,25 +23,54 @@ var (
 
 	// SamplingPriority determines the priority of sampling this Span.
 	SamplingPriority = uint16Tag("sampling.priority")
+
+	// SpanKind hints at relationship between spans, e.g. client/server
+	SpanKind = spanKindTag("span.kind")
+
+	// SpanKindRPCClient marks a span representing the client-side of an RPC
+	// or other remote call
+	SpanKindRPCClient = SpanKindEnum("c")
+
+	// SpanKindRPCServer marks a span representing the server-side of an RPC
+	// or other remote call
+	SpanKindRPCServer = SpanKindEnum("s")
 )
+
+// ---
+
+// SpanKindEnum represents common span types
+type SpanKindEnum string
+
+type spanKindTag string
+
+// Add adds a string tag to the `span`
+func (tag spanKindTag) Set(span opentracing.Span, value SpanKindEnum) {
+	span.SetTag(string(tag), value)
+}
+
+// ---
 
 type stringTag string
 
 // Add adds a string tag to the `span`
-func (tag stringTag) Add(span opentracing.Span, value string) {
+func (tag stringTag) Set(span opentracing.Span, value string) {
 	span.SetTag(string(tag), value)
 }
+
+// ---
 
 type uint32Tag string
 
 // Add adds a uint32 tag to the `span`
-func (tag uint32Tag) Add(span opentracing.Span, value uint32) {
+func (tag uint32Tag) Set(span opentracing.Span, value uint32) {
 	span.SetTag(string(tag), value)
 }
+
+// ---
 
 type uint16Tag string
 
 // Add adds a uint16 tag to the `span`
-func (tag uint16Tag) Add(span opentracing.Span, value uint16) {
+func (tag uint16Tag) Set(span opentracing.Span, value uint16) {
 	span.SetTag(string(tag), value)
 }

--- a/ext/tags_test.go
+++ b/ext/tags_test.go
@@ -21,11 +21,14 @@ func TestPeerTags(t *testing.T) {
 	}
 	tracer := noopTracer{}
 	span := tracer.StartSpan("my-trace")
-	ext.PeerService.Add(span, "my-service")
-	ext.PeerHostname.Add(span, "my-hostname")
-	ext.PeerHostIPv4.Add(span, uint32(127<<24|1))
-	ext.PeerHostIPv6.Add(span, "::")
-	ext.PeerPort.Add(span, uint16(8080))
+	ext.PeerService.Set(span, "my-service")
+	ext.PeerHostname.Set(span, "my-hostname")
+	ext.PeerHostIPv4.Set(span, uint32(127<<24|1))
+	ext.PeerHostIPv6.Set(span, "::")
+	ext.PeerPort.Set(span, uint16(8080))
+	ext.SamplingPriority.Set(span, uint16(1))
+	ext.SpanKind.Set(span, ext.SpanKindRPCServer)
+	ext.SpanKind.Set(span, ext.SpanKindRPCClient)
 	span.Finish()
 
 	rawSpan := span.(*noopSpan)


### PR DESCRIPTION
Brings Go in parity with Python, where span kind tags have been defined for a while.