### PR TITLE
Simplify propagation by removing an API layer

### DIFF
--- a/ext/tags_test.go
+++ b/ext/tags_test.go
@@ -43,8 +43,6 @@ type noopSpan struct {
 	Tags opentracing.Tags
 }
 
-type noopInjectorExtractor struct{}
-
 func (n noopSpan) SetTag(key string, value interface{}) opentracing.Span {
 	n.Tags[key] = value
 	return n
@@ -68,18 +66,10 @@ func (n noopTracer) StartSpanWithOptions(opts opentracing.StartSpanOptions) open
 	return noopSpan{Tags: make(opentracing.Tags)}
 }
 
-func (n noopTracer) Extractor(format interface{}) opentracing.Extractor {
-	return noopInjectorExtractor{}
+func (n noopTracer) Inject(toInject opentracing.Span, format interface{}, carrier interface{}) error {
+	panic("not implemented")
 }
 
-func (n noopTracer) Injector(format interface{}) opentracing.Injector {
-	return noopInjectorExtractor{}
-}
-
-func (n noopInjectorExtractor) InjectSpan(span opentracing.Span, carrier interface{}) error {
-	return nil
-}
-
-func (n noopInjectorExtractor) JoinTrace(operationName string, carrier interface{}) (opentracing.Span, error) {
+func (n noopTracer) Join(operationName string, format interface{}, carrier interface{}) (opentracing.Span, error) {
 	panic("not implemented")
 }

--- a/ext/tags_test.go
+++ b/ext/tags_test.go
@@ -66,7 +66,7 @@ func (n noopTracer) StartSpanWithOptions(opts opentracing.StartSpanOptions) open
 	return noopSpan{Tags: make(opentracing.Tags)}
 }
 
-func (n noopTracer) Inject(toInject opentracing.Span, format interface{}, carrier interface{}) error {
+func (n noopTracer) Inject(sp opentracing.Span, format interface{}, carrier interface{}) error {
 	panic("not implemented")
 }
 

--- a/noop.go
+++ b/noop.go
@@ -41,7 +41,7 @@ func (n NoopTracer) StartSpanWithOptions(opts StartSpanOptions) Span {
 }
 
 // Inject belongs to the Tracer interface.
-func (n NoopTracer) Inject(toInject Span, format interface{}, carrier interface{}) error {
+func (n NoopTracer) Inject(sp Span, format interface{}, carrier interface{}) error {
 	return nil
 }
 

--- a/noop.go
+++ b/noop.go
@@ -5,15 +5,13 @@ package opentracing
 type NoopTracer struct{}
 
 type noopSpan struct{}
-type noopInjectorExtractor struct{}
 
 var (
-	defaultNoopSpan              = noopSpan{}
-	defaultNoopInjectorExtractor = noopInjectorExtractor{}
-	defaultNoopTracer            = NoopTracer{}
-	emptyTags                    = Tags{}
-	emptyBytes                   = []byte{}
-	emptyStringMap               = map[string]string{}
+	defaultNoopSpan   = noopSpan{}
+	defaultNoopTracer = NoopTracer{}
+	emptyTags         = Tags{}
+	emptyBytes        = []byte{}
+	emptyStringMap    = map[string]string{}
 )
 
 const (
@@ -42,20 +40,12 @@ func (n NoopTracer) StartSpanWithOptions(opts StartSpanOptions) Span {
 	return defaultNoopSpan
 }
 
-// Extractor belongs to the Tracer interface.
-func (n NoopTracer) Extractor(format interface{}) Extractor {
-	return defaultNoopInjectorExtractor
-}
-
-// Injector belongs to the Tracer interface.
-func (n NoopTracer) Injector(format interface{}) Injector {
-	return defaultNoopInjectorExtractor
-}
-
-func (n noopInjectorExtractor) InjectSpan(span Span, carrier interface{}) error {
+// Inject belongs to the Tracer interface.
+func (n NoopTracer) Inject(toInject Span, format interface{}, carrier interface{}) error {
 	return nil
 }
 
-func (n noopInjectorExtractor) JoinTrace(operationName string, carrier interface{}) (Span, error) {
+// Join belongs to the Tracer interface.
+func (n NoopTracer) Join(operationName string, format interface{}, carrier interface{}) (Span, error) {
 	return nil, ErrTraceNotFound
 }

--- a/propagation.go
+++ b/propagation.go
@@ -9,12 +9,12 @@ import "errors"
 var (
 	// ErrUnsupportedFormat occurs when the `format` passed to Tracer.Inject() or
 	// Tracer.Join() is not recognized by the Tracer implementation.
-	ErrUnsupportedFormat = errors.New("opentracing: Unknown or unsupported inject/join format")
+	ErrUnsupportedFormat = errors.New("opentracing: Unknown or unsupported Inject/Join format")
 
 	// ErrTraceNotFound occurs when the `carrier` passed to Tracer.Join() is
 	// valid and uncorrupted but has insufficient information to join or resume
 	// a trace.
-	ErrTraceNotFound = errors.New("opentracing: Trace not found in Extraction carrier")
+	ErrTraceNotFound = errors.New("opentracing: Trace not found in Join carrier")
 
 	// ErrInvalidSpan errors occur when Tracer.Inject() is asked to operate on
 	// a Span which it is not prepared to handle (for example, since it was
@@ -24,11 +24,11 @@ var (
 	// ErrInvalidCarrier errors occur when Tracer.Inject() or Tracer.Join()
 	// implementations expect a different type of `carrier` than they are
 	// given.
-	ErrInvalidCarrier = errors.New("opentracing: Invalid Injection/Extraction carrier")
+	ErrInvalidCarrier = errors.New("opentracing: Invalid Inject/Join carrier")
 
 	// ErrTraceCorrupted occurs when the `carrier` passed to Tracer.Join() is
 	// of the expected type but is corrupted.
-	ErrTraceCorrupted = errors.New("opentracing: Trace data corrupted in Extraction carrier")
+	ErrTraceCorrupted = errors.New("opentracing: Trace data corrupted in Join carrier")
 )
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/propagation.go
+++ b/propagation.go
@@ -7,66 +7,36 @@ import "errors"
 ///////////////////////////////////////////////////////////////////////////////
 
 var (
-	// ErrTraceNotFound occurs when the `carrier` passed to Extractor.JoinTrace()
-	// is valid and uncorrupted but has insufficient information to join or
-	// resume a trace.
+	// ErrUnsupportedFormat occurs when the `format` passed to Tracer.Inject() or
+	// Tracer.Join() is not recognized by the Tracer implementation.
+	ErrUnsupportedFormat = errors.New("opentracing: Unknown or unsupported inject/join format")
+
+	// ErrTraceNotFound occurs when the `carrier` passed to Tracer.Join() is
+	// valid and uncorrupted but has insufficient information to join or resume
+	// a trace.
 	ErrTraceNotFound = errors.New("opentracing: Trace not found in Extraction carrier")
 
-	// ErrInvalidSpan errors occur when Injector.InjectSpan() is asked to operate
-	// on a Span which it is not prepared to handle (for example, since it was
+	// ErrInvalidSpan errors occur when Tracer.Inject() is asked to operate on
+	// a Span which it is not prepared to handle (for example, since it was
 	// created by a different tracer implementation).
 	ErrInvalidSpan = errors.New("opentracing: Span type incompatible with tracer")
 
-	// ErrInvalidCarrier errors occur when Injector.InjectSpan() or
-	// Extractor.JoinTrace() implementations expect a different type of
-	// `carrier` than they are given.
+	// ErrInvalidCarrier errors occur when Tracer.Inject() or Tracer.Join()
+	// implementations expect a different type of `carrier` than they are
+	// given.
 	ErrInvalidCarrier = errors.New("opentracing: Invalid Injection/Extraction carrier")
 
-	// ErrTraceCorrupted occurs when the `carrier` passed to Extractor.JoinTrace()
-	// is of the expected type but is corrupted.
+	// ErrTraceCorrupted occurs when the `carrier` passed to Tracer.Join() is
+	// of the expected type but is corrupted.
 	ErrTraceCorrupted = errors.New("opentracing: Trace data corrupted in Extraction carrier")
 )
-
-// Injector is responsible for injecting Span instances in a manner suitable
-// for propagation via a format-specific "carrier" object. Typically the
-// injection will take place across an RPC boundary, but message queues and
-// other IPC mechanisms are also reasonable places to use an Injector.
-//
-// See Extractor and Tracer.Injector.
-type Injector interface {
-	// InjectSpan takes `span` and injects it into `carrier`. The actual type
-	// of `carrier` depends on the `format` passed to `Tracer.Injector()`.
-	//
-	// Implementations may return opentracing.ErrInvalidCarrier or any other
-	// implementation-specific error if injection fails.
-	InjectSpan(span Span, carrier interface{}) error
-}
-
-// Extractor is responsible for extracting Span instances from an
-// format-specific "carrier" object. Typically the extraction will take place
-// on the server side of an RPC boundary, but message queues and other IPC
-// mechanisms are also reasonable places to use an Extractor.
-//
-// See Injector and Tracer.Extractor.
-type Extractor interface {
-	// JoinTrace returns a Span instance with operation name `operationName`
-	// given `carrier`, or (nil, opentracing.ErrTraceNotFound) if no trace could be found to
-	// join with in the `carrier`.
-	//
-	// Implementations may return opentracing.ErrInvalidCarrier,
-	// opentracing.ErrTraceCorrupted, or implementation-specific errors if there
-	// are more fundamental problems with `carrier`.
-	//
-	// Upon success, the returned Span instance is already started.
-	JoinTrace(operationName string, carrier interface{}) (Span, error)
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 // BUILTIN PROPAGATION FORMATS:
 ///////////////////////////////////////////////////////////////////////////////
 
 // BuiltinFormat is used to demarcate the values within package `opentracing`
-// that are intended for use with the Tracer.Injector() and Tracer.Extractor()
+// that are intended for use with the Tracer.Inject() and Tracer.Join()
 // methods.
 type BuiltinFormat byte
 

--- a/span.go
+++ b/span.go
@@ -1,8 +1,6 @@
 package opentracing
 
 import (
-	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -184,16 +182,7 @@ func StartChildSpan(parent Span, operationName string) Span {
 	})
 }
 
-// InjectSpan is a helper that injects a Span instance into a carrier.
-//
-// See Tracer.Injector() and Injector.InjectSpan().
+// InjectSpan is a trivial helper that injects a Span instance into a carrier.
 func InjectSpan(sp Span, format interface{}, carrier interface{}) error {
-	var inj Injector
-	if inj = sp.Tracer().Injector(format); inj == nil {
-		return fmt.Errorf(
-			"Unsupported PropagationFormat: %v (type: %v)",
-			format,
-			reflect.TypeOf(format))
-	}
-	return inj.InjectSpan(sp, carrier)
+	return sp.Tracer().Inject(sp, format, carrier)
 }

--- a/span.go
+++ b/span.go
@@ -181,8 +181,3 @@ func StartChildSpan(parent Span, operationName string) Span {
 		Parent:        parent,
 	})
 }
-
-// InjectSpan is a trivial helper that injects a Span instance into a carrier.
-func InjectSpan(sp Span, format interface{}, carrier interface{}) error {
-	return sp.Tracer().Inject(sp, format, carrier)
-}

--- a/tracer.go
+++ b/tracer.go
@@ -27,9 +27,9 @@ type Tracer interface {
 	StartSpan(operationName string) Span
 	StartSpanWithOptions(opts StartSpanOptions) Span
 
-	// Inject() takes the `toInject` Span instance and represents it for
-	// propagation within `carrier`. The actual type of `carrier` depends on
-	// the value of `format`.
+	// Inject() takes the `sp` Span instance and represents it for propagation
+	// within `carrier`. The actual type of `carrier` depends on the value of
+	// `format`.
 	//
 	// OpenTracing defines a common set of `format` values (see BuiltinFormat),
 	// and each has an expected carrier type.
@@ -56,7 +56,7 @@ type Tracer interface {
 	// fails anyway.
 	//
 	// See Tracer.Join().
-	Inject(toInject Span, format interface{}, carrier interface{}) error
+	Inject(sp Span, format interface{}, carrier interface{}) error
 
 	// Join() returns a Span instance with operation name `operationName` given
 	// `format` and `carrier`.

--- a/tracer.go
+++ b/tracer.go
@@ -5,7 +5,7 @@ import "time"
 // Tracer is a simple, thin interface for Span creation.
 //
 // A straightforward implementation is available via the
-// `opentracing/basictracer` package's `standardtracer.New()'.
+// `opentracing/basictracer-go` package's `standardtracer.New()'.
 type Tracer interface {
 	// Create, start, and return a new Span with the given `operationName`, all
 	// without specifying a parent Span that can be used to incorporate the
@@ -27,29 +27,9 @@ type Tracer interface {
 	StartSpan(operationName string) Span
 	StartSpanWithOptions(opts StartSpanOptions) Span
 
-	// Return an Injector for the given `format` value, or nil if the Tracer
-	// does not support such a format.
-	//
-	// OpenTracing defines a common set of `format` values (see
-	// BuiltinFormat), and each has an expected carrier type.
-	//
-	// Other packages may declare their own `format` values, much like the keys
-	// used by the `net.Context` package (see
-	// https://godoc.org/golang.org/x/net/context#WithValue).
-	//
-	// Example usage (sans error handling):
-	//
-	//     tracer.Injector(
-	//         opentracing.GoHTTPHeader).InjectSpan(
-	//         span, httpReq.Header)
-	//
-	// NOTE: All opentracing.Tracer implementations MUST support all
-	// BuiltinFormats.
-	//
-	Injector(format interface{}) Injector
-
-	// Return a Extractor for the given `format` value, or nil if the Tracer
-	// does not support such a format.
+	// Inject() takes the `toInject` Span instance and represents it for
+	// propagation within `carrier`. The actual type of `carrier` depends on
+	// the value of `format`.
 	//
 	// OpenTracing defines a common set of `format` values (see BuiltinFormat),
 	// and each has an expected carrier type.
@@ -60,14 +40,62 @@ type Tracer interface {
 	//
 	// Example usage (sans error handling):
 	//
-	//     span, err := tracer.Extractor(
-	//         opentracing.GoHTTPHeader).JoinTrace(
-	//         operationName, httpReq.Header)
+	//     tracer.Inject(
+	//         span,
+	//         opentracing.GoHTTPHeader,
+	//         httpReq.Header)
 	//
 	// NOTE: All opentracing.Tracer implementations MUST support all
 	// BuiltinFormats.
 	//
-	Extractor(format interface{}) Extractor
+	// Implementations may return opentracing.ErrUnsupportedFormat if `format`
+	// is or not supported by (or not known by) the implementation.
+	//
+	// Implementations may return opentracing.ErrInvalidCarrier or any other
+	// implementation-specific error if the format is supported but injection
+	// fails anyway.
+	//
+	// See Tracer.Join().
+	Inject(toInject Span, format interface{}, carrier interface{}) error
+
+	// Join() returns a Span instance with operation name `operationName` given
+	// `format` and `carrier`.
+	//
+	// Join() is responsible for extracting and joining to the trace of a Span
+	// instance embedded in a format-specific "carrier" object. Typically the
+	// joining will take place on the server side of an RPC boundary, but
+	// message queues and other IPC mechanisms are also reasonable places to
+	// use Join().
+	//
+	// OpenTracing defines a common set of `format` values (see BuiltinFormat),
+	// and each has an expected carrier type.
+	//
+	// Other packages may declare their own `format` values, much like the keys
+	// used by the `net.Context` package (see
+	// https://godoc.org/golang.org/x/net/context#WithValue).
+	//
+	// Example usage (sans error handling):
+	//
+	//     span, err := tracer.Join(
+	//         operationName,
+	//         opentracing.GoHTTPHeader,
+	//         httpReq.Header)
+	//
+	// NOTE: All opentracing.Tracer implementations MUST support all
+	// BuiltinFormats.
+	//
+	// Return values:
+	//  - A successful join will return a started Span instance and a nil error
+	//  - If there was simply no trace to join with in `carrier`, Join()
+	//    returns (nil, opentracing.ErrTraceNotFound)
+	//  - If `format` is unsupported or unrecognized, Join() returns (nil,
+	//    opentracing.ErrUnsupportedFormat)
+	//  - If there are more fundamental problems with the `carrier` object,
+	//    Join() may return opentracing.ErrInvalidCarrier,
+	//    opentracing.ErrTraceCorrupted, or implementation-specific errors.
+	//
+	// See Tracer.Inject().
+	Join(operationName string, format interface{}, carrier interface{}) (Span, error)
 }
 
 // StartSpanOptions allows Tracer.StartSpanWithOptions callers to override the

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,6 @@
 package opentracing
 
 import (
-	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -23,18 +22,14 @@ func InjectSpanInHeader(
 	sp Span,
 	h http.Header,
 ) error {
-	// First, look for a GoHTTPHeader injector (our preference).
-	injector := sp.Tracer().Injector(GoHTTPHeader)
-	if injector != nil {
-		return injector.InjectSpan(sp, h)
+	// First, try to inject using the GoHTTPHeader format (our preference).
+	if err := InjectSpan(sp, GoHTTPHeader, h); err == nil {
+		return nil
 	}
 
 	// Else, fall back on SplitText.
-	if injector = sp.Tracer().Injector(SplitText); injector == nil {
-		return errors.New("No suitable injector")
-	}
 	carrier := NewSplitTextCarrier()
-	if err := injector.InjectSpan(sp, carrier); err != nil {
+	if err := InjectSpan(sp, SplitText, carrier); err != nil {
 		return err
 	}
 	for headerSuffix, val := range carrier.TracerState {
@@ -46,28 +41,23 @@ func InjectSpanInHeader(
 	return nil
 }
 
-// JoinTraceFromHeader decodes a Span with operation name `operationName` from
-// `h`, expecting that header values are URL-escpaed.
+// JoinFromHeader decodes a Span with operation name `operationName` from `h`,
+// expecting that header values are URL-escpaed.
 //
 // If `operationName` is empty, the caller must later call
 // `Span.SetOperationName` on the returned `Span`.
-func JoinTraceFromHeader(
+func JoinFromHeader(
 	operationName string,
 	h http.Header,
 	tracer Tracer,
 ) (Span, error) {
-	// First, look for a GoHTTPHeader extractor (our
-	// preference).
-	extractor := tracer.Extractor(GoHTTPHeader)
-	if extractor != nil {
-		return extractor.JoinTrace(operationName, h)
+	// First, try to Join using the GoHTTPHeader format (our preference).
+	span, err := tracer.Join(operationName, GoHTTPHeader, h)
+	if err == nil {
+		return span, nil
 	}
 
 	// Else, fall back on SplitText.
-	if extractor = tracer.Extractor(SplitText); extractor == nil {
-		return nil, errors.New("No suitable extractor")
-	}
-
 	carrier := NewSplitTextCarrier()
 	for key, val := range h {
 		if strings.HasPrefix(key, ContextIDHTTPHeaderPrefix) {
@@ -86,5 +76,5 @@ func JoinTraceFromHeader(
 			carrier.Baggage[strings.TrimPrefix(key, TagsHTTPHeaderPrefix)] = unescaped
 		}
 	}
-	return extractor.JoinTrace(operationName, carrier)
+	return tracer.Join(operationName, SplitText, carrier)
 }

--- a/utils.go
+++ b/utils.go
@@ -23,13 +23,13 @@ func InjectSpanInHeader(
 	h http.Header,
 ) error {
 	// First, try to inject using the GoHTTPHeader format (our preference).
-	if err := InjectSpan(sp, GoHTTPHeader, h); err == nil {
+	if err := sp.Tracer().Inject(sp, GoHTTPHeader, h); err == nil {
 		return nil
 	}
 
 	// Else, fall back on SplitText.
 	carrier := NewSplitTextCarrier()
-	if err := InjectSpan(sp, SplitText, carrier); err != nil {
+	if err := sp.Tracer().Inject(sp, SplitText, carrier); err != nil {
 		return err
 	}
 	for headerSuffix, val := range carrier.TracerState {


### PR DESCRIPTION
Per https://github.com/opentracing/opentracing.github.io/issues/70 . The Tracer.Injector() calls were going to be 1:1 with Injector.InjectSpan() calls, and the Tracer.Extractor() calls were going to be 1:1 with Extractor.JoinTrace() calls; this change cuts out the middleman.

@tschottdorf @bg451 @yurishkuro what do we want to do about `basictracer-go`? I can do this change in a way that breaks nothing there (i.e., temporarily support both APIs in OT-go, remove all deps on the old one, remove old API, etc, etc) or I can stage a change in `basictracer-go` and merge the two in close succession. No strong feelings either way but wanted to check whether anyone is depending on `basictracer-go` in a way where that sort of short-term breakage is unacceptable. (If so, I will obviously do the cleaner/laborious thing)