### PR TITLE
Change Go-Context methods not to return the input span

### DIFF
--- a/gocontext.go
+++ b/gocontext.go
@@ -8,20 +8,14 @@ var activeSpanKey = contextKey{}
 
 // ContextWithSpan returns a new `context.Context` that holds a reference to
 // the given `Span`.
-//
-// The second return value is simply the `span` passed in:
-// this can save some typing and is only provided as a convenience.
-func ContextWithSpan(ctx context.Context, span Span) (context.Context, Span) {
-	return context.WithValue(ctx, activeSpanKey, span), span
+func ContextWithSpan(ctx context.Context, span Span) context.Context {
+	return context.WithValue(ctx, activeSpanKey, span)
 }
 
 // BackgroundContextWithSpan is a convenience wrapper around
 // `ContextWithSpan(context.BackgroundContext(), ...)`.
-//
-// The second return value is simply the `span` passed in:
-// this can save some typing and is only provided as a convenience.
-func BackgroundContextWithSpan(span Span) (context.Context, Span) {
-	return context.WithValue(context.Background(), activeSpanKey, span), span
+func BackgroundContextWithSpan(span Span) context.Context {
+	return context.WithValue(context.Background(), activeSpanKey, span)
 }
 
 // SpanFromContext returns the `Span` previously associated with `ctx`, or

--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -1,0 +1,27 @@
+package opentracing
+
+import (
+	"testing"
+	"golang.org/x/net/context"
+)
+
+func TestContextWithSpan(t *testing.T) {
+	span := &noopSpan{}
+	ctx := BackgroundContextWithSpan(span)
+	span2 := SpanFromContext(ctx)
+	if span != span2 {
+		t.Errorf("Not the same span returned from context, expected=%+v, actual=%+v", span, span2)
+	}
+
+	ctx = context.Background()
+	span2 = SpanFromContext(ctx)
+	if span2 != nil {
+		t.Errorf("Expected nil span, found %+v", span2)
+	}
+
+	ctx = ContextWithSpan(ctx, span)
+	span2 = SpanFromContext(ctx)
+	if span != span2 {
+		t.Errorf("Not the same span returned from context, expected=%+v, actual=%+v", span, span2)
+	}
+}


### PR DESCRIPTION
Per gitter conversation, returning the input span is only useful in very specialized cases, like this:

```go
ctx, span := opentracing.ContextWithSpan(ctx, tracer.StartSpan(…))
```