### PR TITLE
Fix a nil map assignment in JoinFromHeader

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -66,12 +66,18 @@ func JoinFromHeader(
 			if err != nil {
 				return nil, err
 			}
+			if carrier.TracerState == nil {
+				carrier.TracerState = map[string]string{}
+			}
 			carrier.TracerState[strings.TrimPrefix(key, ContextIDHTTPHeaderPrefix)] = unescaped
 		} else if strings.HasPrefix(key, TagsHTTPHeaderPrefix) {
 			// We don't know what to do with anything beyond slice item v[0]:
 			unescaped, err := url.QueryUnescape(val[0])
 			if err != nil {
 				return nil, err
+			}
+			if carrier.Baggage == nil {
+				carrier.Baggage = map[string]string{}
 			}
 			carrier.Baggage[strings.TrimPrefix(key, TagsHTTPHeaderPrefix)] = unescaped
 		}


### PR DESCRIPTION
`JoinFromHeader` now creates the appropriate map if the `SplitTextCarrier`'s map are nil, since `NewSplitTextCarrier` doesn't create any maps. This fixes a nil map assignment bug for when a `Tracer` doesn't implement `Join` for `GoHTTPHeader` and tries to use `Join` for `SplitText`.

Here's the panic in action.

```
2016/03/05 09:46:59 http: panic serving [::1]:51661: assignment to entry in nil map
goroutine 11 [running]:
net/http.(*conn).serve.func1(0xc8200c7b80, 0x86edd0, 0xc820032168)
	/usr/local/go/src/net/http/server.go:1287 +0xb5
github.com/opentracing/opentracing-go.JoinFromHeader(0x4ecba0, 0xa, 0xc82019a000, 0x86ec00, 0xc820118e10, 0x0, 0x0, 0x0, 0x0)
	/Users/bg/go/src/github.com/opentracing/opentracing-go/utils.go:76 +0x87d
main.server.func1(0xba0058, 0xc8201a0000, 0xc82011a700)
	/Users/bg/go/src/sourcegraph.com/sourcegraph/appdash/opentracing/example/main.go:65 +0x6d
net/http.HandlerFunc.ServeHTTP(0x5a5a00, 0xba0058, 0xc8201a0000, 0xc82011a700)
	/usr/local/go/src/net/http/server.go:1422 +0x3a
net/http.(*ServeMux).ServeHTTP(0xc820016960, 0xba0058, 0xc8201a0000, 0xc82011a700)
	/usr/local/go/src/net/http/server.go:1699 +0x17d
net/http.serverHandler.ServeHTTP(0xc82015a000, 0xba0058, 0xc8201a0000, 0xc82011a700)
	/usr/local/go/src/net/http/server.go:1862 +0x19e
net/http.(*conn).serve(0xc8200c7b80)
	/usr/local/go/src/net/http/server.go:1361 +0xbee
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:1910 +0x3f6
```