### PR TITLE
Add StartSpanFromContext (and testTracer)

### DIFF
--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -2,6 +2,7 @@ package opentracing
 
 import (
 	"testing"
+
 	"golang.org/x/net/context"
 )
 
@@ -23,5 +24,34 @@ func TestContextWithSpan(t *testing.T) {
 	span2 = SpanFromContext(ctx)
 	if span != span2 {
 		t.Errorf("Not the same span returned from context, expected=%+v, actual=%+v", span, span2)
+	}
+}
+
+func TestStartSpanFromContext(t *testing.T) {
+	testTracer := testTracer{}
+
+	// Test the case where there *is* a Span in the Context.
+	{
+		parentSpan := &testSpan{}
+		parentCtx := BackgroundContextWithSpan(parentSpan)
+		childSpan, childCtx := startSpanFromContextWithTracer(parentCtx, "child", testTracer)
+		if !childSpan.(testSpan).HasParent {
+			t.Errorf("Failed to find parent: %v", childSpan)
+		}
+		if childSpan != SpanFromContext(childCtx) {
+			t.Errorf("Unable to find child span in context: %v", childCtx)
+		}
+	}
+
+	// Test the case where there *is not* a Span in the Context.
+	{
+		emptyCtx := context.Background()
+		childSpan, childCtx := startSpanFromContextWithTracer(emptyCtx, "child", testTracer)
+		if childSpan.(testSpan).HasParent {
+			t.Errorf("Should not have found parent: %v", childSpan)
+		}
+		if childSpan != SpanFromContext(childCtx) {
+			t.Errorf("Unable to find child span in context: %v", childCtx)
+		}
 	}
 }

--- a/noop.go
+++ b/noop.go
@@ -9,9 +9,6 @@ type noopSpan struct{}
 var (
 	defaultNoopSpan   = noopSpan{}
 	defaultNoopTracer = NoopTracer{}
-	emptyTags         = Tags{}
-	emptyBytes        = []byte{}
-	emptyStringMap    = map[string]string{}
 )
 
 const (

--- a/testtracer_test.go
+++ b/testtracer_test.go
@@ -1,0 +1,48 @@
+package opentracing
+
+// testTracer is a most-noop Tracer implementation that makes it possible for
+// unittests to verify whether certain methods were / were not called.
+type testTracer struct{}
+
+type testSpan struct {
+	OperationName string
+	HasParent     bool
+}
+
+// testSpan:
+func (n testSpan) SetTag(key string, value interface{}) Span             { return n }
+func (n testSpan) Finish()                                               {}
+func (n testSpan) FinishWithOptions(opts FinishOptions)                  {}
+func (n testSpan) SetBaggageItem(key, val string) Span                   { return n }
+func (n testSpan) BaggageItem(key string) string                         { return "" }
+func (n testSpan) LogEvent(event string)                                 {}
+func (n testSpan) LogEventWithPayload(event string, payload interface{}) {}
+func (n testSpan) Log(data LogData)                                      {}
+func (n testSpan) SetOperationName(operationName string) Span            { return n }
+func (n testSpan) Tracer() Tracer                                        { return testTracer{} }
+
+// StartSpan belongs to the Tracer interface.
+func (n testTracer) StartSpan(operationName string) Span {
+	return testSpan{
+		OperationName: operationName,
+		HasParent:     false,
+	}
+}
+
+// StartSpanWithOptions belongs to the Tracer interface.
+func (n testTracer) StartSpanWithOptions(opts StartSpanOptions) Span {
+	return testSpan{
+		OperationName: opts.OperationName,
+		HasParent:     opts.Parent != nil,
+	}
+}
+
+// Inject belongs to the Tracer interface.
+func (n testTracer) Inject(sp Span, format interface{}, carrier interface{}) error {
+	return nil
+}
+
+// Join belongs to the Tracer interface.
+func (n testTracer) Join(operationName string, format interface{}, carrier interface{}) (Span, error) {
+	return nil, ErrTraceNotFound
+}


### PR DESCRIPTION
I've found myself wanting this function over and over again in my own Go instrumentation code... thoughts?

@beberlei @yurishkuro @tschottdorf @bg451 have you done something else for (safely/concisely) creating a `Span` from a `context.Context`?