### PR TITLE
allow RPCServerOption to be used without a parent client

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,13 @@ reference.
         if err != nil {
             // Optionally record something about err here
         }
-        if wireContext != nil {
-            // Create a span referring to the RPC client.
-            serverSpan = opentracing.StartSpan(
-                appSpecificOperationName,
-                ext.RPCServerOption(wireContext))
-        } else {
-            // Create a root span.
-            serverSpan = opentracing.StartSpan(appSpecificOperationName)
-        }
+
+        // Create the span referring to the RPC client if available.
+        // If wireContext == nil, a root span will be created.
+        serverSpan = opentracing.StartSpan(
+            appSpecificOperationName,
+            ext.RPCServerOption(wireContext))
+
         defer serverSpan.Finish()
 
         ctx := opentracing.ContextWithSpan(context.Background(), serverSpan)

--- a/ext/tags.go
+++ b/ext/tags.go
@@ -112,7 +112,9 @@ func (r rpcServerOption) Apply(o *opentracing.StartSpanOptions) {
 }
 
 // RPCServerOption returns a StartSpanOption appropriate for an RPC server span
-// with `client` representing the metadata for the remote peer Span.
+// with `client` representing the metadata for the remote peer Span if available.
+// In case client == nil, due to the client not being instrumented, this RPC
+// server span will be a root span.
 func RPCServerOption(client opentracing.SpanContext) opentracing.StartSpanOption {
 	return rpcServerOption{client}
 }

--- a/ext/tags.go
+++ b/ext/tags.go
@@ -105,7 +105,9 @@ type rpcServerOption struct {
 }
 
 func (r rpcServerOption) Apply(o *opentracing.StartSpanOptions) {
-	opentracing.ChildOf(r.clientContext).Apply(o)
+	if r.clientContext != nil {
+		opentracing.ChildOf(r.clientContext).Apply(o)
+	}
 	(opentracing.Tags{string(SpanKind): SpanKindRPCServer}).Apply(o)
 }
 


### PR DESCRIPTION
it is very common for a server at the edge (ex. api gateway) to start an RPC server tagged span without a Client as the client might not have instrumentation. This change allows for clientContext to be nil