### PR TITLE
Introduce CarriedChildOfOption and CarriedFollowsFromOption

### DIFF
--- a/ext/options.go
+++ b/ext/options.go
@@ -1,0 +1,43 @@
+package ext
+
+import (
+	"github.com/opentracing/opentracing-go"
+)
+
+// TODO move RPCServerOption into this file? OR, remove it. Code such as:
+//
+// err := tracer.Extract(...)
+// if err != nil { ... }
+// tracer.StartSpan("...", RPCServerOption(...))
+//
+// can be rewritten as:
+// tracer.StartSpan("...", SpanKindRPCServer, ChildOfCarrierOption(...))
+
+type extractedOption struct {
+	ref             opentracing.SpanReferenceType
+	format, carrier interface{}
+}
+
+// Apply implements the StartSpanOption interface.
+func (e extractedOption) Apply(tracer opentracing.Tracer, o *opentracing.StartSpanOptions) {
+	spanCtx, err := tracer.Extract(e.format, e.carrier)
+	if spanCtx != nil {
+		opentracing.SpanReference{e.ref, spanCtx}.Apply(tracer, o)
+	}
+	if err != nil {
+		opentracing.Tag{string(CarriedContextError), err.Error()}.Apply(tracer, o)
+	}
+}
+
+func CarriedSpanRefOption(ref opentracing.SpanReferenceType,
+	format, carrier interface{}) opentracing.StartSpanOption {
+	return extractedOption{ref, format, carrier}
+}
+
+func CarriedChildOfOption(format, carrier interface{}) opentracing.StartSpanOption {
+	return CarriedSpanRefOption(opentracing.ChildOfRef, format, carrier)
+}
+
+func CarriedFollowsFromOption(format, carrier interface{}) opentracing.StartSpanOption {
+	return CarriedSpanRefOption(opentracing.FollowsFromRef, format, carrier)
+}

--- a/ext/options.go
+++ b/ext/options.go
@@ -29,15 +29,22 @@ func (e extractedOption) Apply(tracer opentracing.Tracer, o *opentracing.StartSp
 	}
 }
 
+// CarriedSpanRefOption extracts a context from "carrier" (of type "format")
+// and returns a StartSpanOption that will the associated context as a span
+// reference of type "ref" to a newly started span.
 func CarriedSpanRefOption(ref opentracing.SpanReferenceType,
 	format, carrier interface{}) opentracing.StartSpanOption {
 	return extractedOption{ref, format, carrier}
 }
 
+// CarriedChildOfOption constructs a opentracing.ChildOfRef SpanReference option
+// for use in StartSpan with a carried context.
 func CarriedChildOfOption(format, carrier interface{}) opentracing.StartSpanOption {
 	return CarriedSpanRefOption(opentracing.ChildOfRef, format, carrier)
 }
 
+// FollowsFrom constructs a opentracing.FollowsFrom SpanReference option
+// for use in StartSpan with a carried context.
 func CarriedFollowsFromOption(format, carrier interface{}) opentracing.StartSpanOption {
 	return CarriedSpanRefOption(opentracing.FollowsFromRef, format, carrier)
 }

--- a/ext/options_test.go
+++ b/ext/options_test.go
@@ -1,0 +1,26 @@
+package ext_test
+
+import (
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/mocktracer"
+)
+
+func TestCarriedOption(t *testing.T) {
+	tracer := mocktracer.New()
+	parent := tracer.StartSpan("my-trace")
+
+	carrier := opentracing.HTTPHeaderTextMapCarrier{}
+	err := tracer.Inject(parent.Context(), opentracing.TextMap, carrier)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tracer.StartSpan("my-child", ext.CarriedChildOfOption(opentracing.TextMap, carrier)).Finish()
+
+	rawSpan := tracer.GetFinishedSpans()[0]
+	assertEqual(t, rawSpan.ParentID, parent.Context().(*mocktracer.MockSpanContext).SpanID)
+	assertEqual(t, rawSpan.ParentRelationship, opentracing.ChildOfRef)
+}

--- a/ext/tags.go
+++ b/ext/tags.go
@@ -35,6 +35,8 @@ var (
 	// Component name
 	//////////////////////////////////////////////////////////////////////
 
+	CarriedContextError = stringTag("carried.context.error")
+
 	// Component is a low-cardinality identifier of the module, library,
 	// or package that is generating a span.
 	Component = stringTag("component")
@@ -106,11 +108,11 @@ type rpcServerOption struct {
 	clientContext opentracing.SpanContext
 }
 
-func (r rpcServerOption) Apply(o *opentracing.StartSpanOptions) {
+func (r rpcServerOption) Apply(t opentracing.Tracer, o *opentracing.StartSpanOptions) {
 	if r.clientContext != nil {
-		opentracing.ChildOf(r.clientContext).Apply(o)
+		opentracing.ChildOf(r.clientContext).Apply(t, o)
 	}
-	SpanKindRPCServer.Apply(o)
+	SpanKindRPCServer.Apply(t, o)
 }
 
 // RPCServerOption returns a StartSpanOption appropriate for an RPC server span

--- a/testtracer_test.go
+++ b/testtracer_test.go
@@ -47,7 +47,7 @@ func (n testSpan) Tracer() Tracer                                        { retur
 func (n testTracer) StartSpan(operationName string, opts ...StartSpanOption) Span {
 	sso := StartSpanOptions{}
 	for _, o := range opts {
-		o.Apply(&sso)
+		o.Apply(n, &sso)
 	}
 	return n.startSpanWithOptions(operationName, sso)
 }


### PR DESCRIPTION
These are StartSpanOption values that hide a call to tracer.Extract. In case of error, they annotate the span with an error instead of returning it to the caller.