### PR TITLE
Allow nil argument to ChildOf/FollowsFrom

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,31 @@
+package opentracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChildOfAndFollowsFrom(t *testing.T) {
+	tests := []struct {
+		newOpt  func(SpanContext) SpanReference
+		refType SpanReferenceType
+		name    string
+	}{
+		{ChildOf, ChildOfRef, "ChildOf"},
+		{FollowsFrom, FollowsFromRef, "FollowsFrom"},
+	}
+
+	for _, test := range tests {
+		opts := new(StartSpanOptions)
+
+		test.newOpt(nil).Apply(opts)
+		require.Nil(t, opts.References, "%s(nil) must not append a reference", test.name)
+
+		ctx := new(noopSpanContext)
+		test.newOpt(ctx).Apply(opts)
+		require.Equal(t, []SpanReference{
+			SpanReference{Referee: ctx, Type: test.refType},
+		}, opts.References, "%s(ctx) must append a reference", test.name)
+	}
+}

--- a/tracer.go
+++ b/tracer.go
@@ -214,7 +214,7 @@ const (
 // it allows for a more concise syntax for starting spans:
 //
 //     sc, _ := tracer.Extract(someFormat, someCarrier)
-//     span := tracer.StartSpan("operation", ChildOf(sc))
+//     span := tracer.StartSpan("operation", opentracing.ChildOf(sc))
 //
 // The `ChildOf(sc)` option above will not panic if sc == nil, it will just
 // not add the parent span reference to the options.
@@ -231,8 +231,9 @@ func (r SpanReference) Apply(o *StartSpanOptions) {
 }
 
 // ChildOf returns a StartSpanOption pointing to a dependent parent span.
+// If sm == nil, the option has no effect.
 //
-// See ChildOfRef
+// See ChildOfRef, SpanReference
 func ChildOf(sm SpanContext) SpanReference {
 	return SpanReference{
 		Type:    ChildOfRef,
@@ -242,8 +243,9 @@ func ChildOf(sm SpanContext) SpanReference {
 
 // FollowsFrom returns a StartSpanOption pointing to a parent Span that caused
 // the child Span but does not directly depend on its result in any way.
+// If sm == nil, the option has no effect.
 //
-// See FollowsFromRef
+// See FollowsFromRef, SpanReference
 func FollowsFrom(sm SpanContext) SpanReference {
 	return SpanReference{
 		Type:    FollowsFromRef,

--- a/tracer.go
+++ b/tracer.go
@@ -209,7 +209,15 @@ const (
 
 // SpanReference is a StartSpanOption that pairs a SpanReferenceType and a
 // referee SpanContext ("referee" is "the one who is referred to"). See the
-// SpanReferenceType documentation.
+// SpanReferenceType documentation for supported relationships.
+// If SpanReference is created with Referee == nil, it has no effect. Thus
+// it allows for a more concise syntax for starting spans:
+//
+//     sc, _ := tracer.Extract(someFormat, someCarrier)
+//     span := tracer.StartSpan("operation", ChildOf(sc))
+//
+// The `ChildOf(sc)` option above will not panic if sc == nil, it will just
+// not add the parent span reference to the options.
 type SpanReference struct {
 	Type    SpanReferenceType
 	Referee SpanContext

--- a/tracer.go
+++ b/tracer.go
@@ -231,25 +231,25 @@ func (r SpanReference) Apply(o *StartSpanOptions) {
 }
 
 // ChildOf returns a StartSpanOption pointing to a dependent parent span.
-// If sm == nil, the option has no effect.
+// If sc == nil, the option has no effect.
 //
 // See ChildOfRef, SpanReference
-func ChildOf(sm SpanContext) SpanReference {
+func ChildOf(sc SpanContext) SpanReference {
 	return SpanReference{
 		Type:    ChildOfRef,
-		Referee: sm,
+		Referee: sc,
 	}
 }
 
 // FollowsFrom returns a StartSpanOption pointing to a parent Span that caused
 // the child Span but does not directly depend on its result in any way.
-// If sm == nil, the option has no effect.
+// If sc == nil, the option has no effect.
 //
 // See FollowsFromRef, SpanReference
-func FollowsFrom(sm SpanContext) SpanReference {
+func FollowsFrom(sc SpanContext) SpanReference {
 	return SpanReference{
 		Type:    FollowsFromRef,
-		Referee: sm,
+		Referee: sc,
 	}
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -217,7 +217,9 @@ type SpanReference struct {
 
 // Apply satisfies the StartSpanOption interface.
 func (r SpanReference) Apply(o *StartSpanOptions) {
-	o.References = append(o.References, r)
+	if r.Referee != nil {
+		o.References = append(o.References, r)
+	}
 }
 
 // ChildOf returns a StartSpanOption pointing to a dependent parent span.


### PR DESCRIPTION
Reason: to simplify span starting code by not forcing nil checks:

```go
sc, _ := tracer.Extract(someFormat, someCarrier)
span := tracer.StartSpan("operation", ChildOf(sc)) // should work even if sc == nil
```

cc @bensigelman