### PR TITLE
Strip Get prefix from methods

### DIFF
--- a/ext/tags_test.go
+++ b/ext/tags_test.go
@@ -26,7 +26,7 @@ func TestPeerTags(t *testing.T) {
 	ext.SpanKindRPCClient.Set(span)
 	span.Finish()
 
-	rawSpan := tracer.GetFinishedSpans()[0]
+	rawSpan := tracer.FinishedSpans()[0]
 	assert.Equal(t, map[string]interface{}{
 		"peer.service":  "my-service",
 		"peer.hostname": "my-hostname",
@@ -34,7 +34,7 @@ func TestPeerTags(t *testing.T) {
 		"peer.ipv6":     "::",
 		"peer.port":     uint16(8080),
 		"span.kind":     ext.SpanKindRPCClientEnum,
-	}, rawSpan.GetTags())
+	}, rawSpan.Tags())
 	assert.True(t, span.Context().(*mocktracer.MockSpanContext).Sampled)
 	ext.SamplingPriority.Set(span, uint16(0))
 	assert.False(t, span.Context().(*mocktracer.MockSpanContext).Sampled)
@@ -48,13 +48,13 @@ func TestHTTPTags(t *testing.T) {
 	ext.HTTPStatusCode.Set(span, 301)
 	span.Finish()
 
-	rawSpan := tracer.GetFinishedSpans()[0]
+	rawSpan := tracer.FinishedSpans()[0]
 	assert.Equal(t, map[string]interface{}{
 		"http.url":         "test.biz/uri?protocol=false",
 		"http.method":      "GET",
 		"http.status_code": uint16(301),
 		"span.kind":        ext.SpanKindRPCServerEnum,
-	}, rawSpan.GetTags())
+	}, rawSpan.Tags())
 }
 
 func TestMiscTags(t *testing.T) {
@@ -66,11 +66,11 @@ func TestMiscTags(t *testing.T) {
 
 	span.Finish()
 
-	rawSpan := tracer.GetFinishedSpans()[0]
+	rawSpan := tracer.FinishedSpans()[0]
 	assert.Equal(t, map[string]interface{}{
 		"component": "my-awesome-library",
 		"error":     true,
-	}, rawSpan.GetTags())
+	}, rawSpan.Tags())
 }
 
 func TestRPCServerOption(t *testing.T) {
@@ -91,11 +91,11 @@ func TestRPCServerOption(t *testing.T) {
 
 	tracer.StartSpan("my-child", ext.RPCServerOption(parCtx)).Finish()
 
-	rawSpan := tracer.GetFinishedSpans()[0]
+	rawSpan := tracer.FinishedSpans()[0]
 	assert.Equal(t, map[string]interface{}{
 		"span.kind": ext.SpanKindRPCServerEnum,
-	}, rawSpan.GetTags())
+	}, rawSpan.Tags())
 	assert.Equal(t, map[string]string{
 		"bag": "gage",
-	}, rawSpan.Context().(*mocktracer.MockSpanContext).GetBaggage())
+	}, rawSpan.Context().(*mocktracer.MockSpanContext).Baggage())
 }

--- a/mocktracer/mocktracer.go
+++ b/mocktracer/mocktracer.go
@@ -74,8 +74,8 @@ func (s *MockSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
 	}
 }
 
-// GetBaggage returns a copy of baggage items in the span
-func (s *MockSpanContext) GetBaggage() map[string]string {
+// Baggage returns a copy of baggage items in the span
+func (s *MockSpanContext) Baggage() map[string]string {
 	s.RLock()
 	defer s.RUnlock()
 	baggage := make(map[string]string)
@@ -102,9 +102,9 @@ type MockSpan struct {
 	tracer      *MockTracer
 }
 
-// GetFinishedSpans returns all spans that have been Finish()'ed since the
+// FinishedSpans returns all spans that have been Finish()'ed since the
 // MockTracer was constructed or since the last call to its Reset() method.
-func (t *MockTracer) GetFinishedSpans() []*MockSpan {
+func (t *MockTracer) FinishedSpans() []*MockSpan {
 	t.RLock()
 	defer t.RUnlock()
 	spans := make([]*MockSpan, len(t.finishedSpans))
@@ -121,8 +121,8 @@ func (t *MockTracer) Reset() {
 	t.finishedSpans = []*MockSpan{}
 }
 
-// GetTags returns a copy of tags accumulated by the span so far
-func (s *MockSpan) GetTags() map[string]interface{} {
+// Tags returns a copy of tags accumulated by the span so far
+func (s *MockSpan) Tags() map[string]interface{} {
 	s.spanContext.RLock()
 	defer s.spanContext.RUnlock()
 	tags := make(map[string]interface{})
@@ -132,15 +132,15 @@ func (s *MockSpan) GetTags() map[string]interface{} {
 	return tags
 }
 
-// GetTag returns a single tag
-func (s *MockSpan) GetTag(k string) interface{} {
+// Tag returns a single tag
+func (s *MockSpan) Tag(k string) interface{} {
 	s.spanContext.RLock()
 	defer s.spanContext.RUnlock()
 	return s.tags[k]
 }
 
-// GetLogs returns a copy of logs accumulated in the span so far
-func (s *MockSpan) GetLogs() []opentracing.LogData {
+// Logs returns a copy of logs accumulated in the span so far
+func (s *MockSpan) Logs() []opentracing.LogData {
 	s.spanContext.RLock()
 	defer s.spanContext.RUnlock()
 	logs := make([]opentracing.LogData, len(s.logs))
@@ -265,7 +265,7 @@ func newMockSpan(t *MockTracer, name string, opts opentracing.StartSpanOptions) 
 	if len(opts.References) > 0 {
 		traceID = opts.References[0].Referee.(*MockSpanContext).TraceID
 		parentID = opts.References[0].Referee.(*MockSpanContext).SpanID
-		baggage = opts.References[0].Referee.(*MockSpanContext).GetBaggage()
+		baggage = opts.References[0].Referee.(*MockSpanContext).Baggage()
 		sampled = opts.References[0].Referee.(*MockSpanContext).Sampled
 	}
 	spanContext := newMockSpanContext(traceID, nextMockID(), sampled, baggage)

--- a/mocktracer/mocktracer_test.go
+++ b/mocktracer/mocktracer_test.go
@@ -20,12 +20,12 @@ func TestMockTracer_StartSpan(t *testing.T) {
 		"", opentracing.ChildOf(span1.Context()))
 	span2.Finish()
 	span1.Finish()
-	spans := tracer.GetFinishedSpans()
+	spans := tracer.FinishedSpans()
 	assert.Equal(t, 2, len(spans))
 
 	parent := spans[1]
 	child := spans[0]
-	assert.Equal(t, map[string]interface{}{"x": "y"}, parent.GetTags())
+	assert.Equal(t, map[string]interface{}{"x": "y"}, parent.Tags())
 	assert.Equal(t, child.ParentID, parent.Context().(*MockSpanContext).SpanID)
 }
 
@@ -41,7 +41,7 @@ func TestMockSpanContext_Baggage(t *testing.T) {
 	span := tracer.StartSpan("x")
 	span.Context().SetBaggageItem("x", "y")
 	assert.Equal(t, "y", span.Context().BaggageItem("x"))
-	assert.Equal(t, map[string]string{"x": "y"}, span.Context().(*MockSpanContext).GetBaggage())
+	assert.Equal(t, map[string]string{"x": "y"}, span.Context().(*MockSpanContext).Baggage())
 
 	baggage := make(map[string]string)
 	span.Context().ForeachBaggageItem(func(k, v string) bool {
@@ -56,35 +56,35 @@ func TestMockSpanContext_Baggage(t *testing.T) {
 		baggage[k] = v
 		return false // exit early
 	})
-	assert.Equal(t, 2, len(span.Context().(*MockSpanContext).GetBaggage()))
+	assert.Equal(t, 2, len(span.Context().(*MockSpanContext).Baggage()))
 	assert.Equal(t, 1, len(baggage))
 }
 
-func TestMockSpan_GetTag(t *testing.T) {
+func TestMockSpan_Tag(t *testing.T) {
 	tracer := New()
 	span := tracer.StartSpan("x")
 	span.SetTag("x", "y")
-	assert.Equal(t, "y", span.(*MockSpan).GetTag("x"))
+	assert.Equal(t, "y", span.(*MockSpan).Tag("x"))
 }
 
-func TestMockSpan_GetTags(t *testing.T) {
+func TestMockSpan_Tags(t *testing.T) {
 	tracer := New()
 	span := tracer.StartSpan("x")
 	span.SetTag("x", "y")
-	assert.Equal(t, map[string]interface{}{"x": "y"}, span.(*MockSpan).GetTags())
+	assert.Equal(t, map[string]interface{}{"x": "y"}, span.(*MockSpan).Tags())
 }
 
-func TestMockTracer_GetFinishedSpans_and_Reset(t *testing.T) {
+func TestMockTracer_FinishedSpans_and_Reset(t *testing.T) {
 	tracer := New()
 	span := tracer.StartSpan("x")
 	span.SetTag("x", "y")
 	span.Finish()
-	spans := tracer.GetFinishedSpans()
+	spans := tracer.FinishedSpans()
 	assert.Equal(t, 1, len(spans))
-	assert.Equal(t, map[string]interface{}{"x": "y"}, spans[0].GetTags())
+	assert.Equal(t, map[string]interface{}{"x": "y"}, spans[0].Tags())
 
 	tracer.Reset()
-	spans = tracer.GetFinishedSpans()
+	spans = tracer.FinishedSpans()
 	assert.Equal(t, 0, len(spans))
 }
 
@@ -96,14 +96,14 @@ func TestMockSpan_Logs(t *testing.T) {
 	span.Log(opentracing.LogData{Event: "a"})
 	span.FinishWithOptions(opentracing.FinishOptions{
 		BulkLogData: []opentracing.LogData{opentracing.LogData{Event: "f"}}})
-	spans := tracer.GetFinishedSpans()
+	spans := tracer.FinishedSpans()
 	assert.Equal(t, 1, len(spans))
 	assert.Equal(t, []opentracing.LogData{
 		opentracing.LogData{Event: "x"},
 		opentracing.LogData{Event: "y", Payload: "z"},
 		opentracing.LogData{Event: "a"},
 		opentracing.LogData{Event: "f"},
-	}, spans[0].GetLogs())
+	}, spans[0].Logs())
 }
 
 func TestMockTracer_Propagation(t *testing.T) {


### PR DESCRIPTION
This change removes the Get prefix from mocktracer GetBaggage, GetTags, and GetFinishedSpans, per the Go idiom for accessor methods.

r @yurishkuro @bensigelman 