### PR TITLE
Update documentation example for HTTPHeaders BuiltinFormat

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -85,7 +85,7 @@ const (
 	//
 	//    carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
 	//    span, err := tracer.Extract(
-	//        "opName", opentracing.HTTPHeaders, carrier)
+	//        opentracing.HTTPHeaders, carrier)
 	//
 	HTTPHeaders
 )


### PR DESCRIPTION
As `Tracer.Extract` does not take a first `opName` string parameter.