### PR TITLE
Remove URL escaping from HTTPHeadersCarrier and add a test for it

### DIFF
--- a/ext/tags.go
+++ b/ext/tags.go
@@ -24,12 +24,12 @@ var (
 	// SpanKindRPCClient marks a span representing the client-side of an RPC
 	// or other remote call
 	SpanKindRPCClientEnum = SpanKindEnum("client")
-	SpanKindRPCClient     = opentracing.Tag{string(SpanKind), SpanKindRPCClientEnum}
+	SpanKindRPCClient     = opentracing.Tag{Key: string(SpanKind), Value: SpanKindRPCClientEnum}
 
 	// SpanKindRPCServer marks a span representing the server-side of an RPC
 	// or other remote call
 	SpanKindRPCServerEnum = SpanKindEnum("server")
-	SpanKindRPCServer     = opentracing.Tag{string(SpanKind), SpanKindRPCServerEnum}
+	SpanKindRPCServer     = opentracing.Tag{Key: string(SpanKind), Value: SpanKindRPCServerEnum}
 
 	//////////////////////////////////////////////////////////////////////
 	// Component name

--- a/mocktracer/mocktracer.go
+++ b/mocktracer/mocktracer.go
@@ -19,8 +19,10 @@ func New() *MockTracer {
 	textPropagator := new(TextMapPropagator)
 	t.RegisterInjector(opentracing.TextMap, textPropagator)
 	t.RegisterExtractor(opentracing.TextMap, textPropagator)
-	t.RegisterInjector(opentracing.HTTPHeaders, textPropagator)
-	t.RegisterExtractor(opentracing.HTTPHeaders, textPropagator)
+
+	httpPropagator := &TextMapPropagator{HTTPHeaders: true}
+	t.RegisterInjector(opentracing.HTTPHeaders, httpPropagator)
+	t.RegisterExtractor(opentracing.HTTPHeaders, httpPropagator)
 
 	return t
 }

--- a/mocktracer/mocktracer_test.go
+++ b/mocktracer/mocktracer_test.go
@@ -111,7 +111,7 @@ func TestMockTracer_Propagation(t *testing.T) {
 	textCarrier := func() interface{} {
 		return opentracing.TextMapCarrier(make(map[string]string))
 	}
-	textLen := func (c interface{}) int {
+	textLen := func(c interface{}) int {
 		return len(c.(opentracing.TextMapCarrier))
 	}
 
@@ -119,7 +119,7 @@ func TestMockTracer_Propagation(t *testing.T) {
 		httpHeaders := http.Header(make(map[string][]string))
 		return opentracing.HTTPHeadersCarrier(httpHeaders)
 	}
-	httpLen := func (c interface{}) int {
+	httpLen := func(c interface{}) int {
 		return len(c.(opentracing.HTTPHeadersCarrier))
 	}
 
@@ -127,7 +127,7 @@ func TestMockTracer_Propagation(t *testing.T) {
 		sampled bool
 		format  opentracing.BuiltinFormat
 		carrier func() interface{}
-		len func(interface{}) int
+		len     func(interface{}) int
 	}{
 		{sampled: true, format: opentracing.TextMap, carrier: textCarrier, len: textLen},
 		{sampled: false, format: opentracing.TextMap, carrier: textCarrier, len: textLen},

--- a/propagation.go
+++ b/propagation.go
@@ -3,7 +3,6 @@ package opentracing
 import (
 	"errors"
 	"net/http"
-	"net/url"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -147,21 +146,14 @@ type HTTPHeadersCarrier http.Header
 // Set conforms to the TextMapWriter interface.
 func (c HTTPHeadersCarrier) Set(key, val string) {
 	h := http.Header(c)
-	h.Add(key, url.QueryEscape(val))
+	h.Add(key, val)
 }
 
 // ForeachKey conforms to the TextMapReader interface.
 func (c HTTPHeadersCarrier) ForeachKey(handler func(key, val string) error) error {
 	for k, vals := range c {
 		for _, v := range vals {
-			rawV, err := url.QueryUnescape(v)
-			if err != nil {
-				// We don't know if there was an error escaping an
-				// OpenTracing-related header or something else; as such, we
-				// continue rather than return the error.
-				continue
-			}
-			if err = handler(k, rawV); err != nil {
+			if err := handler(k, v); err != nil {
 				return err
 			}
 		}

--- a/propagation.go
+++ b/propagation.go
@@ -141,6 +141,20 @@ func (c TextMapCarrier) Set(key, val string) {
 }
 
 // HTTPHeadersCarrier satisfies both TextMapWriter and TextMapReader.
+//
+// Example usage for server side:
+//
+//     carrier := opentracing.HttpHeadersCarrier(httpReq.Header)
+//     spanContext, err := tracer.Extract(opentracing.HttpHeaders, carrier)
+//
+// Example usage for client side:
+//
+//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+//     err := tracer.Inject(
+//         span.Context(),
+//         opentracing.HttpHeaders,
+//         carrier)
+//
 type HTTPHeadersCarrier http.Header
 
 // Set conforms to the TextMapWriter interface.


### PR DESCRIPTION
Support HTTPHeaders format in MockTracer with URL escaping

Addresses https://github.com/opentracing/opentracing.github.io/issues/113