### PR TITLE
Pass options along when creating a span with StartSpanFromContext

### DIFF
--- a/gocontext.go
+++ b/gocontext.go
@@ -48,10 +48,10 @@ func StartSpanFromContext(ctx context.Context, operationName string, opts ...Sta
 func startSpanFromContextWithTracer(ctx context.Context, tracer Tracer, operationName string, opts ...StartSpanOption) (Span, context.Context) {
 	var span Span
 	if parentSpan := SpanFromContext(ctx); parentSpan != nil {
-		span = tracer.StartSpan(
-			operationName, ChildOf(parentSpan.Context()))
+		opts = append(opts, ChildOf(parentSpan.Context()))
+		span = tracer.StartSpan(operationName, opts...)
 	} else {
-		span = tracer.StartSpan(operationName)
+		span = tracer.StartSpan(operationName, opts...)
 	}
 	return span, ContextWithSpan(ctx, span)
 }

--- a/testtracer_test.go
+++ b/testtracer_test.go
@@ -33,25 +33,25 @@ type testSpan struct {
 	Tags          map[string]interface{}
 }
 
-func (s testSpan) Equal(os Span) bool {
+func (n testSpan) Equal(os Span) bool {
 	other, ok := os.(testSpan)
 	if !ok {
 		return false
 	}
-	if s.spanContext != other.spanContext {
+	if n.spanContext != other.spanContext {
 		return false
 	}
-	if s.OperationName != other.OperationName {
+	if n.OperationName != other.OperationName {
 		return false
 	}
-	if !s.StartTime.Equal(other.StartTime) {
+	if !n.StartTime.Equal(other.StartTime) {
 		return false
 	}
-	if len(s.Tags) != len(other.Tags) {
+	if len(n.Tags) != len(other.Tags) {
 		return false
 	}
 
-	for k, v := range s.Tags {
+	for k, v := range n.Tags {
 		if ov, ok := other.Tags[k]; !ok || ov != v {
 			return false
 		}

--- a/testtracer_test.go
+++ b/testtracer_test.go
@@ -3,6 +3,7 @@ package opentracing
 import (
 	"strconv"
 	"strings"
+	"time"
 )
 
 const testHTTPHeaderPrefix = "testprefix-"
@@ -28,6 +29,35 @@ func (n testSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
 type testSpan struct {
 	spanContext   testSpanContext
 	OperationName string
+	StartTime     time.Time
+	Tags          map[string]interface{}
+}
+
+func (s testSpan) Equal(os Span) bool {
+	other, ok := os.(testSpan)
+	if !ok {
+		return false
+	}
+	if s.spanContext != other.spanContext {
+		return false
+	}
+	if s.OperationName != other.OperationName {
+		return false
+	}
+	if !s.StartTime.Equal(other.StartTime) {
+		return false
+	}
+	if len(s.Tags) != len(other.Tags) {
+		return false
+	}
+
+	for k, v := range s.Tags {
+		if ov, ok := other.Tags[k]; !ok || ov != v {
+			return false
+		}
+	}
+
+	return true
 }
 
 // testSpan:
@@ -57,8 +87,11 @@ func (n testTracer) startSpanWithOptions(name string, opts StartSpanOptions) Spa
 	if len(opts.References) > 0 {
 		fakeID = opts.References[0].ReferencedContext.(testSpanContext).FakeID
 	}
+
 	return testSpan{
 		OperationName: name,
+		StartTime:     opts.StartTime,
+		Tags:          opts.Tags,
 		spanContext: testSpanContext{
 			HasParent: len(opts.References) > 0,
 			FakeID:    fakeID,


### PR DESCRIPTION
Options were ignored when creating a span.
