### PR TITLE
Drop Go 1.5 that fails in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.5
+  - 1.6
+  - 1.7
   - tip
 
 install:


### PR DESCRIPTION
```
https://travis-ci.org/opentracing/opentracing-go/jobs/179988943

$ go version
go version go1.5 linux/amd64
go.env
$ go env
GOARCH="amd64"
GOBIN=""
GOEXE=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/home/travis/gopath"
GORACE=""
GOROOT="/home/travis/.gimme/versions/go1.5.linux.amd64"
GOTOOLDIR="/home/travis/.gimme/versions/go1.5.linux.amd64/pkg/tool/linux_amd64"
GO15VENDOREXPERIMENT=""
CC="gcc"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0"
CXX="g++"
CGO_ENABLED="1"
install.1
2.28s$ go get -d -t github.com/opentracing/opentracing-go/...
2.63s$ go get -u github.com/golang/lint/...
# golang.org/x/tools/go/gcimporter15
../../../golang.org/x/tools/go/gcimporter15/bexport.go:557: undefined: constant.ToFloat
../../../golang.org/x/tools/go/gcimporter15/gcimporter.go:396: pkg.SetName undefined (type *types.Package has no field or method SetName)
```