### PR TITLE
Fix some usage examples

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -72,18 +72,18 @@ const (
 	//
 	// For Tracer.Extract(): the carrier must be a `TextMapReader`.
 	//
-	// See HTTPHeaderCarrier for an implementation of both TextMapWriter
+	// See HTTPHeadersCarrier for an implementation of both TextMapWriter
 	// and TextMapReader that defers to an http.Header instance for storage.
 	// For example, Inject():
 	//
 	//    carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
 	//    err := span.Tracer().Inject(
-	//        span, opentracing.HTTPHeaders, carrier)
+	//        span.Context(), opentracing.HTTPHeaders, carrier)
 	//
 	// Or Extract():
 	//
 	//    carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
-	//    span, err := tracer.Extract(
+	//    clientContext, err := tracer.Extract(
 	//        opentracing.HTTPHeaders, carrier)
 	//
 	HTTPHeaders
@@ -144,15 +144,15 @@ func (c TextMapCarrier) Set(key, val string) {
 //
 // Example usage for server side:
 //
-//     carrier := opentracing.HttpHeadersCarrier(httpReq.Header)
-//     spanContext, err := tracer.Extract(opentracing.HttpHeaders, carrier)
+//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+//     clientContext, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
 //
 // Example usage for client side:
 //
 //     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
 //     err := tracer.Inject(
 //         span.Context(),
-//         opentracing.HttpHeaders,
+//         opentracing.HTTPHeaders,
 //         carrier)
 //
 type HTTPHeadersCarrier http.Header

--- a/tracer.go
+++ b/tracer.go
@@ -30,7 +30,7 @@ type Tracer interface {
 	//     sp := tracer.StartSpan(
 	//         "GetFeed",
 	//         opentracing.ChildOf(parentSpan.Context()),
-	//         opentracing.Tag("user_agent", loggedReq.UserAgent),
+	//         opentracing.Tag{"user_agent", loggedReq.UserAgent},
 	//         opentracing.StartTime(loggedReq.Timestamp),
 	//     )
 	//


### PR DESCRIPTION
While working on TraceView's OT tracer and porting the [opentracing-python API test harness](https://github.com/opentracing/opentracing-python/blob/master/opentracing/harness/api_check.py) to Go, I noticed not all the usage examples worked against the current OT API.

I also changed "spanContext" to "clientContext" in the propagation.go HTTP Extract examples to match the name @bhs used in tracer.go — hope that is OK!