### PR TITLE
Stop testing with Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.6
   - 1.7
   - 1.8
   - tip


### PR DESCRIPTION
Mainly because Go 1.6 does not allow nested tests. Go 1.8 has been released already, do we need to be testing with more than two recent versions?