### PR TITLE
Add a Skip log field type to log to allow for optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ reference.
     }
 ```
 
+#### Conditionally capture a field using `log.Noop`
+
+In some situations, you may want to dynamically decide whether or not
+to log a field.  For example, you may want to capture additional data,
+such as a customer ID, in non-production environments:
+
+```go
+    func Customer(order *Order) log.Field {
+        if os.Getenv("ENVIRONMENT") == "dev" {
+            return log.String("customer", order.Customer.ID)
+        }
+        return log.Noop()
+    }
+```
+
 #### Goroutine-safety
 
 The entire public API is goroutine-safe and does not require external

--- a/log/field.go
+++ b/log/field.go
@@ -20,7 +20,7 @@ const (
 	errorType
 	objectType
 	lazyLoggerType
-	skipType
+	noopType
 )
 
 // Field instances are constructed via LogBool, LogString, and so on.
@@ -153,7 +153,7 @@ func Lazy(ll LazyLogger) Field {
 	}
 }
 
-// Skip creates a no-op log field that should be ignored by the tracer.
+// Noop creates a no-op log field that should be ignored by the tracer.
 // It can be used to capture optional fields, for example those that should
 // only be logged in non-production environment:
 //
@@ -161,14 +161,14 @@ func Lazy(ll LazyLogger) Field {
 //          if os.Getenv("ENVIRONMENT") == "dev" {
 //              return log.String("customer", order.Customer.ID)
 //          }
-//          return log.Skip()
+//          return log.Noop()
 //     }
 //
 //     span.LogFields(log.String("event", "purchase"), customerField(order))
 //
-func Skip() Field {
+func Noop() Field {
 	return Field{
-		fieldType: skipType,
+		fieldType: noopType,
 	}
 }
 
@@ -223,7 +223,7 @@ func (lf Field) Marshal(visitor Encoder) {
 		visitor.EmitObject(lf.key, lf.interfaceVal)
 	case lazyLoggerType:
 		visitor.EmitLazyLogger(lf.interfaceVal.(LazyLogger))
-	case skipType:
+	case noopType:
 		// intentionally left blank
 	}
 }
@@ -256,7 +256,7 @@ func (lf Field) Value() interface{} {
 		return math.Float64frombits(uint64(lf.numericVal))
 	case errorType, objectType, lazyLoggerType:
 		return lf.interfaceVal
-	case skipType:
+	case noopType:
 		return nil
 	default:
 		return nil

--- a/log/field.go
+++ b/log/field.go
@@ -153,18 +153,22 @@ func Lazy(ll LazyLogger) Field {
 	}
 }
 
-// Skip allows a field to be optionally be included in a Field list.
+// Skip creates a no-op log field that should be ignored by the tracer.
+// It can be used to capture optional fields, for example those that should
+// only be logged in non-production environment:
 //
-// Useful for the construction of composed field types like log.Error
-// to enable them to optionally decide where or not to trace content.
+//     func customerField(order *Order) log.Field {
+//          if os.Getenv("ENVIRONMENT") == "dev" {
+//              return log.String("customer", order.Customer.ID)
+//          }
+//          return log.Skip()
+//     }
 //
-// There are a number of reasons one might wish to dynamically include
-// fields.  For example, if you want to provide additional trace information
-// in non-production environment only.  Another example is if you have
-// fields that may not always be present.
-func Skip(key string) Field {
+//     span.LogFields(log.String("event", "purchase"), customerField(order))
+//
+func Skip() Field {
 	return Field{
-		key:       key,
+		key:       "_",
 		fieldType: skipType,
 	}
 }

--- a/log/field.go
+++ b/log/field.go
@@ -20,6 +20,7 @@ const (
 	errorType
 	objectType
 	lazyLoggerType
+	skipType
 )
 
 // Field instances are constructed via LogBool, LogString, and so on.
@@ -152,6 +153,15 @@ func Lazy(ll LazyLogger) Field {
 	}
 }
 
+// Skip allows for a field to skip the Marshal step.  Useful for constructing
+// optional fields.
+func Skip(key string) Field {
+	return Field{
+		key:       key,
+		fieldType: skipType,
+	}
+}
+
 // Encoder allows access to the contents of a Field (via a call to
 // Field.Marshal).
 //
@@ -203,6 +213,8 @@ func (lf Field) Marshal(visitor Encoder) {
 		visitor.EmitObject(lf.key, lf.interfaceVal)
 	case lazyLoggerType:
 		visitor.EmitLazyLogger(lf.interfaceVal.(LazyLogger))
+	case skipType:
+		// intentionally left blank
 	}
 }
 
@@ -234,6 +246,8 @@ func (lf Field) Value() interface{} {
 		return math.Float64frombits(uint64(lf.numericVal))
 	case errorType, objectType, lazyLoggerType:
 		return lf.interfaceVal
+	case skipType:
+		return nil
 	default:
 		return nil
 	}

--- a/log/field.go
+++ b/log/field.go
@@ -168,7 +168,6 @@ func Lazy(ll LazyLogger) Field {
 //
 func Skip() Field {
 	return Field{
-		key:       "_",
 		fieldType: skipType,
 	}
 }

--- a/log/field.go
+++ b/log/field.go
@@ -153,8 +153,15 @@ func Lazy(ll LazyLogger) Field {
 	}
 }
 
-// Skip allows for a field to skip the Marshal step.  Useful for constructing
-// optional fields.
+// Skip allows a field to be optionally be included in a Field list.
+//
+// Useful for the construction of composed field types like log.Error
+// to enable them to optionally decide where or not to trace content.
+//
+// There are a number of reasons one might wish to dynamically include
+// fields.  For example, if you want to provide additional trace information
+// in non-production environment only.  Another example is if you have
+// fields that may not always be present.
 func Skip(key string) Field {
 	return Field{
 		key:       key,

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -31,7 +31,7 @@ func TestFieldString(t *testing.T) {
 			expected: "error:<nil>",
 		},
 		{
-			field:    Skip(),
+			field:    Noop(),
 			expected: ":<nil>",
 		},
 	}
@@ -42,10 +42,10 @@ func TestFieldString(t *testing.T) {
 	}
 }
 
-func TestSkipDoesNotMarshal(t *testing.T) {
+func TestNoopDoesNotMarshal(t *testing.T) {
 	mockEncoder := struct {
 		Encoder
 	}{}
-	f := Skip()
+	f := Noop()
 	f.Marshal(mockEncoder) // panics if any Encoder method is invoked
 }

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -31,8 +31,8 @@ func TestFieldString(t *testing.T) {
 			expected: "error:<nil>",
 		},
 		{
-			field:    Skip("key"),
-			expected: "key:<nil>",
+			field:    Skip(),
+			expected: "_:<nil>",
 		},
 	}
 	for i, tc := range testCases {
@@ -46,6 +46,6 @@ func TestSkipDoesNotMarshal(t *testing.T) {
 	mockEncoder := struct {
 		Encoder
 	}{}
-	f := Skip("skipped")
+	f := Skip()
 	f.Marshal(mockEncoder) // panics if any Encoder method is invoked
 }

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -32,7 +32,7 @@ func TestFieldString(t *testing.T) {
 		},
 		{
 			field:    Skip(),
-			expected: "_:<nil>",
+			expected: ":<nil>",
 		},
 	}
 	for i, tc := range testCases {

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -30,10 +30,22 @@ func TestFieldString(t *testing.T) {
 			field:    Error(nil),
 			expected: "error:<nil>",
 		},
+		{
+			field:    Skip("key"),
+			expected: "key:<nil>",
+		},
 	}
 	for i, tc := range testCases {
 		if str := tc.field.String(); str != tc.expected {
 			t.Errorf("%d: expected '%s', got '%s'", i, tc.expected, str)
 		}
 	}
+}
+
+func TestSkipDoesNotMarshal(t *testing.T) {
+	mockEncoder := struct {
+		Encoder
+	}{}
+	f := Skip("skipped")
+	f.Marshal(mockEncoder) // panics if any Encoder method is invoked
 }


### PR DESCRIPTION
prevents cluttering of the field list with optional fields that would otherwise be encoded as opt1:nil, opt2:nil, etc
