### PR TITLE
Export StartSpanFromContextWithTracer

### DIFF
--- a/gocontext.go
+++ b/gocontext.go
@@ -41,11 +41,17 @@ func SpanFromContext(ctx context.Context) Span {
 //        ...
 //    }
 func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
-	return startSpanFromContextWithTracer(ctx, GlobalTracer(), operationName, opts...)
+	return StartSpanFromContextWithTracer(ctx, GlobalTracer(), operationName, opts...)
 }
 
-// startSpanFromContextWithTracer is factored out for testing purposes.
-func startSpanFromContextWithTracer(ctx context.Context, tracer Tracer, operationName string, opts ...StartSpanOption) (Span, context.Context) {
+// StartSpanFromContextWithTracer starts and returns a span with `operationName`
+// using  a span found withen the context as a ChildOfRef. If that doesn't exist
+// it creates a root span. It also returns a context.Context object built
+// around the returned span.
+//
+// It's behavior is identical to StartSpanFromContext except that it takes an explicit
+// tracer as opposed to using the global tracer.
+func StartSpanFromContextWithTracer(ctx context.Context, tracer Tracer, operationName string, opts ...StartSpanOption) (Span, context.Context) {
 	var span Span
 	if parentSpan := SpanFromContext(ctx); parentSpan != nil {
 		opts = append(opts, ChildOf(parentSpan.Context()))

--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -36,7 +36,7 @@ func TestStartSpanFromContext(t *testing.T) {
 	{
 		parentSpan := &testSpan{}
 		parentCtx := ContextWithSpan(context.Background(), parentSpan)
-		childSpan, childCtx := startSpanFromContextWithTracer(parentCtx, testTracer, "child")
+		childSpan, childCtx := StartSpanFromContextWithTracer(parentCtx, testTracer, "child")
 		if !childSpan.Context().(testSpanContext).HasParent {
 			t.Errorf("Failed to find parent: %v", childSpan)
 		}
@@ -48,7 +48,7 @@ func TestStartSpanFromContext(t *testing.T) {
 	// Test the case where there *is not* a Span in the Context.
 	{
 		emptyCtx := context.Background()
-		childSpan, childCtx := startSpanFromContextWithTracer(emptyCtx, testTracer, "child")
+		childSpan, childCtx := StartSpanFromContextWithTracer(emptyCtx, testTracer, "child")
 		if childSpan.Context().(testSpanContext).HasParent {
 			t.Errorf("Should not have found parent: %v", childSpan)
 		}
@@ -64,7 +64,7 @@ func TestStartSpanFromContextOptions(t *testing.T) {
 	// Test options are passed to tracer
 
 	startTime := time.Now().Add(-10 * time.Second) // ten seconds ago
-	span, ctx := startSpanFromContextWithTracer(
+	span, ctx := StartSpanFromContextWithTracer(
 		context.Background(), testTracer, "parent", StartTime(startTime), Tag{"component", "test"})
 
 	assert.Equal(t, "test", span.(testSpan).Tags["component"])
@@ -73,7 +73,7 @@ func TestStartSpanFromContextOptions(t *testing.T) {
 	// Test it also works for a child span
 
 	childStartTime := startTime.Add(3 * time.Second)
-	childSpan, _ := startSpanFromContextWithTracer(
+	childSpan, _ := StartSpanFromContextWithTracer(
 		ctx, testTracer, "child", StartTime(childStartTime))
 
 	assert.Equal(t, childSpan.(testSpan).Tags["component"], nil)


### PR DESCRIPTION
Originally discussed in  #149 . This is a fairly simple PR. It just exports a helper function that already exists.

It can be useful for people not using the global tracer. It's only a small thing really, but still, could be nice.