### PR TITLE
add ipv4Tag type for `peer.ipv4` to support add ipv4 string to the `span`

### DIFF
--- a/ext/tags.go
+++ b/ext/tags.go
@@ -73,11 +73,8 @@ var (
 	// PeerHostname records the host name of the peer
 	PeerHostname = stringTagName("peer.hostname")
 
-	// PeerHostIPv4 records IP v4 host address of the peer as an uint32 value, keep this for backward compatibility
-	PeerHostIPv4 = uint32TagName("peer.ipv4")
-
-	// PeerHostIPv4String records IP v4 host address of the peer as a .-separated tuple. E.g., "127.0.0.1"
-	PeerHostIPv4String = stringTagName("peer.ipv4")
+	// PeerHostIPv4 records IP v4 host address of the peer
+	PeerHostIPv4 = ipv4Tag("peer.ipv4")
 
 	// PeerHostIPv6 records IP v6 host address of the peer
 	PeerHostIPv6 = stringTagName("peer.ipv6")
@@ -197,5 +194,17 @@ type boolTagName string
 
 // Add adds a bool tag to the `span`
 func (tag boolTagName) Set(span opentracing.Span, value bool) {
+	span.SetTag(string(tag), value)
+}
+
+type ipv4Tag string
+
+// Set adds IP v4 host address of the peer as an uint32 value to the `span`, keep this for backward and zipkin compatibility
+func (tag ipv4Tag) Set(span opentracing.Span, value uint32) {
+	span.SetTag(string(tag), value)
+}
+
+// SetString records IP v4 host address of the peer as a .-separated tuple to the `span`. E.g., "127.0.0.1"
+func (tag ipv4Tag) SetString(span opentracing.Span, value string) {
 	span.SetTag(string(tag), value)
 }

--- a/ext/tags.go
+++ b/ext/tags.go
@@ -73,8 +73,11 @@ var (
 	// PeerHostname records the host name of the peer
 	PeerHostname = stringTagName("peer.hostname")
 
-	// PeerHostIPv4 records IP v4 host address of the peer
+	// PeerHostIPv4 records IP v4 host address of the peer as an uint32 value, keep this for backward compatibility
 	PeerHostIPv4 = uint32TagName("peer.ipv4")
+
+	// PeerHostIPv4String records IP v4 host address of the peer as a .-separated tuple. E.g., "127.0.0.1"
+	PeerHostIPv4String = stringTagName("peer.ipv4")
 
 	// PeerHostIPv6 records IP v6 host address of the peer
 	PeerHostIPv6 = stringTagName("peer.ipv6")


### PR DESCRIPTION
Fixes #154 