### PR TITLE
propagation: Add AMQP header based carrier support

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -174,3 +174,41 @@ func (c HTTPHeadersCarrier) ForeachKey(handler func(key, val string) error) erro
 	}
 	return nil
 }
+
+// AMQPHeadersCarrier satisfies both TextMapWriter and TextMapReader.
+//
+// Example usage for server side:
+//
+//     carrier := opentracing.AMQPHeadersCarrier(amqp.Table)
+//     clientContext, err := tracer.Extract(
+//         opentracing.TextMap,
+//         carrier)
+//
+// Example usage for client side:
+//
+//     carrier := opentracing.AMQPHeadersCarrier(amqp.Table)
+//     err := tracer.Inject(
+//         span.Context(),
+//         opentracing.TextMap,
+//         carrier)
+//
+type AMQPHeadersCarrier map[string]interface{}
+
+// ForeachKey conforms to the TextMapReader interface.
+func (c AMQPHeadersCarrier) ForeachKey(handler func(key, val string) error) error {
+	for k, val := range c {
+		v, ok := val.(string)
+		if !ok {
+			continue
+		}
+		if err := handler(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set implements Set() of opentracing.TextMapWriter.
+func (c AMQPHeadersCarrier) Set(key, val string) {
+	c[key] = val
+}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -91,3 +91,46 @@ func TestHTTPHeaderExtract(t *testing.T) {
 		t.Errorf("Failed to read testprefix-fakeid correctly")
 	}
 }
+
+func TestAMQPHeaderInject(t *testing.T) {
+	h := map[string]interface{}{}
+	h["NotOT"] =  "blah"
+	h["opname"] = "AlsoNotOT"
+	tracer := testTracer{}
+	span := tracer.StartSpan("someSpan")
+	fakeID := span.Context().(testSpanContext).FakeID
+
+	// Use AMQPHeadersCarrier to wrap around `h`.
+	carrier := AMQPHeadersCarrier(h)
+	if err := span.Tracer().Inject(span.Context(), TextMap, carrier); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(h) != 3 {
+		t.Errorf("Unexpected header length: %v", len(h))
+	}
+	// The prefix comes from just above; the suffix comes from
+	// testTracer.Inject().
+	if h["testprefix-fakeid"] != strconv.Itoa(fakeID) {
+		t.Errorf("Could not find fakeid at expected key")
+	}
+}
+
+func TestAMQPHeaderExtract(t *testing.T) {
+	h := map[string]interface{}{}
+	h["NotOT"] = "blah"
+	h["opname"] = "AlsoNotOT"
+	h["testprefix-fakeid"] = "42"
+	tracer := testTracer{}
+
+	// Use AMQPHeadersCarrier to wrap around `h`.
+	carrier := AMQPHeadersCarrier(h)
+	spanContext, err := tracer.Extract(TextMap, carrier)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if spanContext.(testSpanContext).FakeID != 42 {
+		t.Errorf("Failed to read testprefix-fakeid correctly")
+	}
+}


### PR DESCRIPTION
Adding `AMQPHeadersCarrier` carrier to inject/extract tracing info into the AMQP header through `github.com/streadway/amqp` AMQP/RabbitMQ go package.