### PR TITLE
Fix race condition in MockSpan.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test-and-lint: test lint
 
 .PHONY: test
 test:
-	go test -v -cover ./...
+	go test -v -cover -race ./...
 
 cover:
 	@rm -rf cover-all.out

--- a/mocktracer/mockspan.go
+++ b/mocktracer/mockspan.go
@@ -135,6 +135,8 @@ func (s *MockSpan) Logs() []MockLogRecord {
 
 // Context belongs to the Span interface
 func (s *MockSpan) Context() opentracing.SpanContext {
+	s.Lock()
+	defer s.Unlock()
 	return s.SpanContext
 }
 

--- a/mocktracer/mocktracer_test.go
+++ b/mocktracer/mocktracer_test.go
@@ -266,3 +266,14 @@ func TestMockTracer_Propagation(t *testing.T) {
 		assert.Equal(t, "y:z", extractedContext.(MockSpanContext).Baggage["x"])
 	}
 }
+
+func TestMockSpan_Races(t *testing.T) {
+	tracer := New()
+	span := tracer.StartSpan("x")
+	go func() {
+		span.SetBaggageItem("test_key", "test_value")
+	}()
+	go func() {
+		span.Context()
+	}()
+}

--- a/mocktracer/mocktracer_test.go
+++ b/mocktracer/mocktracer_test.go
@@ -3,6 +3,7 @@ package mocktracer
 import (
 	"net/http"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -268,12 +269,16 @@ func TestMockTracer_Propagation(t *testing.T) {
 }
 
 func TestMockSpan_Races(t *testing.T) {
-	tracer := New()
-	span := tracer.StartSpan("x")
+	span := New().StartSpan("x")
+	var wg sync.WaitGroup
+	wg.Add(2)
 	go func() {
+		defer wg.Done()
 		span.SetBaggageItem("test_key", "test_value")
 	}()
 	go func() {
+		defer wg.Done()
 		span.Context()
 	}()
+	wg.Wait()
 }


### PR DESCRIPTION
The comments in the MockSpan struct indicate that SpanContext is guarded
by the embedded mutex, but no mutex lock is done in the Context()
implementation. This allows for a race condition, for example between
calling Context() and calling SetBaggageItem().