### PR TITLE
Replace 'golang.org/x/net/context' with 'context'

### DIFF
--- a/gocontext.go
+++ b/gocontext.go
@@ -1,6 +1,6 @@
 package opentracing
 
-import "golang.org/x/net/context"
+import "context"
 
 type contextKey struct{}
 

--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -1,11 +1,11 @@
 package opentracing
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestContextWithSpan(t *testing.T) {


### PR DESCRIPTION
The `context` package was introduced in Go 1.7 as a replacement to the `golang.org/x/net/context` package.

Now that we're nearing the release of Go 1.10, we should replace the usage of `golang.org/x/net/context` with the standard library `context`.

This change requires that we drop support for Go 1.6 (#147) and resolves issue #153.