### PR TITLE
Add support for creating Opentracing fields from Zap fields

### DIFF
--- a/log/field_test.go
+++ b/log/field_test.go
@@ -102,10 +102,6 @@ func TestFieldsFromZap(t *testing.T) {
 			zap.Bool("namespace", false),
 			Bool("namespace", false),
 		},
-		{
-			zap.Bool("namespace", true),
-			Bool("namespace", true),
-		},
 	}
 
 	for i, data := range testCases {

--- a/log/util.go
+++ b/log/util.go
@@ -1,6 +1,11 @@
 package log
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+
+	"go.uber.org/zap/zapcore"
+)
 
 // InterleavedKVToFields converts keyValues a la Span.LogKV() to a Field slice
 // a la Span.LogFields().
@@ -51,4 +56,49 @@ func InterleavedKVToFields(keyValues ...interface{}) ([]Field, error) {
 		}
 	}
 	return fields, nil
+}
+
+// FieldFromZap returns a new standard Opentracing Field that contains the same information as the
+// standard Zap field given as input.
+func FieldFromZap(zapField zapcore.Field) Field {
+	switch zapField.Type {
+
+	case zapcore.BoolType:
+		val := false
+		if zapField.Integer >= 1 {
+			val = true
+		}
+		return Bool(zapField.Key, val)
+	case zapcore.Float32Type:
+		return Float32(zapField.Key, math.Float32frombits(uint32(zapField.Integer)))
+	case zapcore.Float64Type:
+		return Float64(zapField.Key, math.Float64frombits(uint64(zapField.Integer)))
+	case zapcore.Int64Type:
+		return Int64(zapField.Key, int64(zapField.Integer))
+	case zapcore.Int32Type:
+		return Int32(zapField.Key, int32(zapField.Integer))
+	case zapcore.StringType:
+		return String(zapField.Key, zapField.String)
+	case zapcore.Uint64Type:
+		return Uint64(zapField.Key, uint64(zapField.Integer))
+	case zapcore.Uint32Type:
+		return Uint32(zapField.Key, uint32(zapField.Integer))
+	case zapcore.ErrorType:
+		return Error(zapField.Interface.(error))
+	default:
+		// By default, use the generic "object" type.
+		return Object(zapField.Key, zapField.Interface)
+	}
+}
+
+// FieldsFromZap returns a slice of Opentracing Fields that contains the same information as a
+// standard Zap field.
+func FieldsFromZap(zapFields ...zapcore.Field) []Field {
+	opentracingFields := make([]Field, len(zapFields))
+
+	for i, zapField := range zapFields {
+		opentracingFields[i] = FieldFromZap(zapField)
+	}
+
+	return opentracingFields
 }


### PR DESCRIPTION
PR to partially implement #175  

This PR adds two funcs:

`func FieldFromZap(zapField zapcore.Field) Field`

and

`func FieldsFromZap(zapFields ...zapcore.Field) []Field`

That can be used by a user that wishes to use Zap fields as input for Opentracing spans.

Essentially, this means that on a project that uses Zap, the user can now use the same set of `...zapcore.Field` to both log to zap and send to Opentracing.

Since `zap` fields are almost the same as `opentracing` fields, the conversion is pretty much straightforward.