### PR TITLE
OpenTracing Semantic Conventions uses error.object

### DIFF
--- a/log/field.go
+++ b/log/field.go
@@ -122,10 +122,10 @@ func Float64(key string, val float64) Field {
 	}
 }
 
-// Error adds an error with the key "error" to a Span.LogFields() record
+// Error adds an error with the key "error.object" to a Span.LogFields() record
 func Error(err error) Field {
 	return Field{
-		key:          "error",
+		key:          "error.object",
 		fieldType:    errorType,
 		interfaceVal: err,
 	}

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -24,11 +24,11 @@ func TestFieldString(t *testing.T) {
 		},
 		{
 			field:    Error(fmt.Errorf("err msg")),
-			expected: "error:err msg",
+			expected: "error.object:err msg",
 		},
 		{
 			field:    Error(nil),
-			expected: "error:<nil>",
+			expected: "error.object:<nil>",
 		},
 		{
 			field:    Noop(),


### PR DESCRIPTION
The OpenTracing Specification suggests "error.object" as the log
key for an error object.

Fixes #164