### PR TITLE
Should use Set() instead of Add() in HTTPHeadersCarrier

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -160,7 +160,7 @@ type HTTPHeadersCarrier http.Header
 // Set conforms to the TextMapWriter interface.
 func (c HTTPHeadersCarrier) Set(key, val string) {
 	h := http.Header(c)
-	h.Add(key, val)
+	h.Set(key, val)
 }
 
 // ForeachKey conforms to the TextMapReader interface.


### PR DESCRIPTION
Should use Set() instead of Add() in HTTPHeadersCarrier. see https://github.com/opentracing/opentracing-go/issues/159