### PR TITLE
Add support to GlobalTracer to indicate if a tracer has been registered

### DIFF
--- a/globaltracer.go
+++ b/globaltracer.go
@@ -36,7 +36,7 @@ func InitGlobalTracer(tracer Tracer) {
 	SetGlobalTracer(tracer)
 }
 
-// IsRegistered returns a `bool` to indicate of a tracer has been globally registered
-func IsRegistered() bool {
+// IsGlobalTracerRegistered returns a `bool` to indicate if a tracer has been globally registered
+func IsGlobalTracerRegistered() bool {
 	return globalTracer.isRegistered
 }

--- a/globaltracer.go
+++ b/globaltracer.go
@@ -1,7 +1,12 @@
 package opentracing
 
+type registeredTracer struct {
+	tracer       Tracer
+	isRegistered bool
+}
+
 var (
-	globalTracer Tracer = NoopTracer{}
+	globalTracer = registeredTracer{NoopTracer{}, false}
 )
 
 // SetGlobalTracer sets the [singleton] opentracing.Tracer returned by
@@ -11,22 +16,27 @@ var (
 // Prior to calling `SetGlobalTracer`, any Spans started via the `StartSpan`
 // (etc) globals are noops.
 func SetGlobalTracer(tracer Tracer) {
-	globalTracer = tracer
+	globalTracer = registeredTracer{tracer, true}
 }
 
 // GlobalTracer returns the global singleton `Tracer` implementation.
 // Before `SetGlobalTracer()` is called, the `GlobalTracer()` is a noop
 // implementation that drops all data handed to it.
 func GlobalTracer() Tracer {
-	return globalTracer
+	return globalTracer.tracer
 }
 
 // StartSpan defers to `Tracer.StartSpan`. See `GlobalTracer()`.
 func StartSpan(operationName string, opts ...StartSpanOption) Span {
-	return globalTracer.StartSpan(operationName, opts...)
+	return globalTracer.tracer.StartSpan(operationName, opts...)
 }
 
 // InitGlobalTracer is deprecated. Please use SetGlobalTracer.
 func InitGlobalTracer(tracer Tracer) {
 	SetGlobalTracer(tracer)
+}
+
+// IsRegistered returns a `bool` to indicate of a tracer has been globally registered
+func IsRegistered() bool {
+	return globalTracer.isRegistered
 }

--- a/globaltracer_test.go
+++ b/globaltracer_test.go
@@ -1,0 +1,26 @@
+package opentracing
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsGlobalTracerRegisteredDefaultIsFalse(t *testing.T) {
+	if IsGlobalTracerRegistered() {
+		t.Errorf("Should return false when no global tracer is registered.")
+	}
+}
+
+func TestAfterSettingGlobalTracerIsGlobalTracerRegisteredReturnsTrue(t *testing.T) {
+	SetGlobalTracer(NoopTracer{})
+
+	if !IsGlobalTracerRegistered() {
+		t.Errorf("Should return true after a tracer has been registered.")
+	}
+}
+
+func TestDefaultTracerIsNoopTracer(t *testing.T) {
+	if reflect.TypeOf(GlobalTracer()) != reflect.TypeOf(NoopTracer{}) {
+		t.Errorf("Should return false when no global tracer is registered.")
+	}
+}


### PR DESCRIPTION
This helps to identify if the global tracer is using the default NoopTracer or has had a tracer registered. This is useful for integration libraries to determine if they can/should set a tracer or use the configured global tracer.

This was first discussed in opentracing/opentracing-csharp#113