### PR TITLE
Fix lint and coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,1 @@
-# IntelliJ project files
-.idea/
-opentracing-go.iml
-opentracing-go.ipr
-opentracing-go.iws
-
-# Test results
-*.cov
-*.html
-test.log
-
-# Build dir
-build/
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,4 @@ script:
   - make test
   - go build ./...
   - if [ "$LINT" == true ]; then make lint ; else echo 'skipping lint'; fi
-
-after_success:
-  - if [ "$COVERAGE" == true ]; then bash <(curl -s https://codecov.io/bash) ; else echo 'skipping coverage'; fi
+  - if [ "$COVERAGE" == true ]; then make cover && bash <(curl -s https://codecov.io/bash) ; else echo 'skipping coverage'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 language: go
 
-go:
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - tip
+matrix:
+  include:
+  - go: "1.7.x"
+  - go: "1.8.x"
+  - go: "1.9.x"
+  - go: "tip"
+    env:
+    - LINT=true
+    - COVERAGE=true
 
 install:
-  - go get -u golang.org/x/lint/golint/...
+  - if [ "$LINT" == true ]; then go get -u golang.org/x/lint/golint/... ; else echo 'skipping lint'; fi
   - go get -u github.com/stretchr/testify/...
   - go get -u golang.org/x/net/context
+
 script:
-  - make test lint
+  - make test
   - go build ./...
+  - if [ "$LINT" == true ]; then make lint ; else echo 'skipping lint'; fi
+
+after_success:
+  - if [ "$COVERAGE" == true ]; then bash <(curl -s https://codecov.io/bash) ; else echo 'skipping coverage'; fi

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .DEFAULT_GOAL := test-and-lint
 
-.PHONE: test-and-lint
-
+.PHONY: test-and-lint
 test-and-lint: test lint
 
 .PHONY: test
 test:
 	go test -v -cover -race ./...
 
+.PHONY: cover
 cover:
 	go test -v -coverprofile=coverage.txt -covermode=atomic -race ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-PACKAGES := . ./mocktracer/... ./ext/... ./log/...
-
 .DEFAULT_GOAL := test-and-lint
 
 .PHONE: test-and-lint
@@ -8,19 +6,10 @@ test-and-lint: test lint
 
 .PHONY: test
 test:
-	go test -v -coverprofile=coverage.txt -covermode=atomic -race ./...
+	go test -v -cover -race ./...
 
 cover:
-	@rm -rf cover-all.out
-	$(foreach pkg, $(PACKAGES), $(MAKE) cover-pkg PKG=$(pkg) || true;)
-	@grep mode: cover.out > coverage.out
-	@cat cover-all.out >> coverage.out
-	go tool cover -html=coverage.out -o cover.html
-	@rm -rf cover.out cover-all.out coverage.out
-
-cover-pkg:
-	go test -coverprofile cover.out $(PKG)
-	@grep -v mode: cover.out >> cover-all.out
+	go test -v -coverprofile=coverage.txt -covermode=atomic -race ./...
 
 .PHONY: lint
 lint:
@@ -29,4 +18,3 @@ lint:
 	@# Run again with magic to exit non-zero if golint outputs anything.
 	@! (golint ./... | read dummy)
 	go vet ./...
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGES := . ./mocktracer/... ./ext/...
+PACKAGES := . ./mocktracer/... ./ext/... ./log/...
 
 .DEFAULT_GOAL := test-and-lint
 
@@ -8,7 +8,7 @@ test-and-lint: test lint
 
 .PHONY: test
 test:
-	go test -v -cover -race ./...
+	go test -v -coverprofile=coverage.txt -covermode=atomic -race ./...
 
 cover:
 	@rm -rf cover-all.out


### PR DESCRIPTION
## Problem
* The old `go get -u github.com/golang/lint/...` no longer works
* The new `go get -u golang.org/x/lint/golint/...` does not work in older Go versions (it uses type alias)
* Coverage was never uploaded

## Fixes
* Use Travis build matrix with env vars to control LINT and COVERAGE
* Only run lint and coverage on tip, not on older versions