### PR TITLE
Fix redundant import alias

### DIFF
--- a/ext/tags.go
+++ b/ext/tags.go
@@ -1,6 +1,6 @@
 package ext
 
-import opentracing "github.com/opentracing/opentracing-go"
+import "github.com/opentracing/opentracing-go"
 
 // These constants define common tag names recommended for better portability across
 // tracing systems and languages/platforms.

--- a/harness/api_checkers.go
+++ b/harness/api_checkers.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"

--- a/harness/noop_api_test.go
+++ b/harness/noop_api_test.go
@@ -3,7 +3,7 @@ package harness
 import (
 	"testing"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 func TestAPI(t *testing.T) {


### PR DESCRIPTION
Because these package names are short and they are unique, it can not conflict. So the import aliases that can be omitted and we should remove them.