### PR TITLE
Change http to https for security links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,5 @@ Changes by Version
 1.0.0 (2016-09-26)
 -------------------
 
-- This release implements OpenTracing Specification 1.0 (http://opentracing.io/spec)
+- This release implements OpenTracing Specification 1.0 (https://opentracing.io/spec)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is a Go platform API for OpenTracing.
 ## Required Reading
 
 In order to understand the Go platform API, one must first be familiar with the
-[OpenTracing project](http://opentracing.io) and
+[OpenTracing project](https://opentracing.io) and
 [terminology](https://opentracing.io/specification/) more specifically.
 
 ## API overview for those adding instrumentation


### PR DESCRIPTION
 For security, we should change http into https links.