### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/ext/tags.go
+++ b/ext/tags.go
@@ -192,7 +192,7 @@ func (tag uint16TagName) Set(span opentracing.Span, value uint16) {
 
 type boolTagName string
 
-// Add adds a bool tag to the `span`
+// Set adds adds a bool tag to the `span`
 func (tag boolTagName) Set(span opentracing.Span, value bool) {
 	span.SetTag(string(tag), value)
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?