### PR TITLE
Fix returned error for Inject

### DIFF
--- a/mocktracer/mocktracer.go
+++ b/mocktracer/mocktracer.go
@@ -80,7 +80,7 @@ func (t *MockTracer) RegisterExtractor(format interface{}, extractor Extractor) 
 func (t *MockTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
 	spanContext, ok := sm.(MockSpanContext)
 	if !ok {
-		return opentracing.ErrInvalidCarrier
+		return opentracing.ErrInvalidSpanContext
 	}
 	injector, ok := t.injectors[format]
 	if !ok {


### PR DESCRIPTION
I think when the passed `SpanContext` is not type of `MockSpanContext`, the error should be `ErrInvalidSpanContext` and not the `ErrInvalidCarrier`