### PR TITLE
Add StartSpanFollowsFromContext function

### DIFF
--- a/gocontext.go
+++ b/gocontext.go
@@ -61,3 +61,36 @@ func StartSpanFromContextWithTracer(ctx context.Context, tracer Tracer, operatio
 	span := tracer.StartSpan(operationName, opts...)
 	return span, ContextWithSpan(ctx, span)
 }
+
+// StartSpanFollowsFromContext starts and returns a Span with `operationName`, using
+// any Span found within `ctx` as a FollowsFromRef. If no such parent could be
+// found, StartSpanFromContext creates a root (parentless) Span.
+//
+// The second return value is a context.Context object built around the
+// returned Span.
+//
+// Example usage:
+//
+//    SomeFunction(ctx context.Context, ...) {
+//        sp, ctx := opentracing.StartSpanFollowsFromContext(ctx, "SomeFunction")
+//        defer sp.Finish()
+//        ...
+//    }
+func StartSpanFollowsFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
+	return StartSpanFollowsFromContextWithTracer(ctx, GlobalTracer(), operationName, opts...)
+}
+
+// StartSpanFollowsFromContextWithTracer starts and returns a span with `operationName`
+// using  a span found within the context as a FollowsFromRef. If that doesn't exist
+// it creates a root span. It also returns a context.Context object built
+// around the returned span.
+//
+// It's behavior is identical to StartSpanFollowsFromContext except that it takes an explicit
+// tracer as opposed to using the global tracer.
+func StartSpanFollowsFromContextWithTracer(ctx context.Context, tracer Tracer, operationName string, opts ...StartSpanOption) (Span, context.Context) {
+	if parentSpan := SpanFromContext(ctx); parentSpan != nil {
+		opts = append(opts, FollowsFrom(parentSpan.Context()))
+	}
+	span := tracer.StartSpan(operationName, opts...)
+	return span, ContextWithSpan(ctx, span)
+}

--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -114,3 +114,54 @@ func TestStartSpanFromContextOptions(t *testing.T) {
 	assert.Equal(t, childSpan.(testSpan).Tags["component"], nil)
 	assert.Equal(t, childSpan.(testSpan).StartTime, childStartTime)
 }
+
+func TestStartSpanFollowsFromContext(t *testing.T) {
+	testTracer := testTracer{}
+
+	// Test the case where there *is* a Span in the Context.
+	{
+		parentSpan := &testSpan{}
+		parentCtx := ContextWithSpan(context.Background(), parentSpan)
+		childSpan, childCtx := StartSpanFollowsFromContextWithTracer(parentCtx, testTracer, "follow")
+		if !childSpan.Context().(testSpanContext).HasParent {
+			t.Errorf("Failed to find parent: %v", childSpan)
+		}
+		if !childSpan.(testSpan).Equal(SpanFromContext(childCtx)) {
+			t.Errorf("Unable to find child span in context: %v", childCtx)
+		}
+	}
+
+	// Test the case where there *is not* a Span in the Context.
+	{
+		emptyCtx := context.Background()
+		childSpan, childCtx := StartSpanFollowsFromContextWithTracer(emptyCtx, testTracer, "follow")
+		if childSpan.Context().(testSpanContext).HasParent {
+			t.Errorf("Should not have found parent: %v", childSpan)
+		}
+		if !childSpan.(testSpan).Equal(SpanFromContext(childCtx)) {
+			t.Errorf("Unable to find child span in context: %v", childCtx)
+		}
+	}
+}
+
+func TestStartSpanFollowsFromContextOptions(t *testing.T) {
+	testTracer := testTracer{}
+
+	// Test options are passed to tracer
+
+	startTime := time.Now().Add(-10 * time.Second) // ten seconds ago
+	span, ctx := StartSpanFollowsFromContextWithTracer(
+		context.Background(), testTracer, "parent", StartTime(startTime), Tag{"component", "test"})
+
+	assert.Equal(t, "test", span.(testSpan).Tags["component"])
+	assert.Equal(t, startTime, span.(testSpan).StartTime)
+
+	// Test it also works for a child span
+
+	childStartTime := startTime.Add(3 * time.Second)
+	childSpan, _ := StartSpanFollowsFromContextWithTracer(
+		ctx, testTracer, "child", StartTime(childStartTime))
+
+	assert.Equal(t, childSpan.(testSpan).Tags["component"], nil)
+	assert.Equal(t, childSpan.(testSpan).StartTime, childStartTime)
+}


### PR DESCRIPTION
I've been working on lots of tracing where data is exchanged via a message broker, so we're always wanting to start spans as followsFrom rather than ChildOf. As far as I can see, there isn't anything out of the box that deals with this so I've added the functions that would do it here, just in case you think this would be useful.