### PR TITLE
ext: Add LogFields helpers for keys from specification

### DIFF
--- a/ext/field.go
+++ b/ext/field.go
@@ -1,0 +1,17 @@
+package ext
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+)
+
+// LogError sets the error=true tag on the Span and logs err as an "error" event.
+func LogError(span opentracing.Span, err error, fields ...log.Field) {
+	Error.Set(span, true)
+	ef := []log.Field{
+		log.Event("error"),
+		log.Error(err),
+	}
+	ef = append(ef, fields...)
+	span.LogFields(ef...)
+}

--- a/ext/field_test.go
+++ b/ext/field_test.go
@@ -1,0 +1,50 @@
+package ext_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+	"github.com/opentracing/opentracing-go/mocktracer"
+)
+
+func TestLogError(t *testing.T) {
+	tracer := mocktracer.New()
+	span := tracer.StartSpan("my-trace")
+	ext.Component.Set(span, "my-awesome-library")
+	ext.SamplingPriority.Set(span, 1)
+	err := fmt.Errorf("my error")
+	ext.LogError(span, err, log.Message("my optional msg text"))
+
+	span.Finish()
+
+	rawSpan := tracer.FinishedSpans()[0]
+	assert.Equal(t, map[string]interface{}{
+		"component": "my-awesome-library",
+		"error":     true,
+	}, rawSpan.Tags())
+
+	assert.Equal(t, len(rawSpan.Logs()), 1)
+	fields := rawSpan.Logs()[0].Fields
+	assert.Equal(t, []mocktracer.MockKeyValue{
+		{
+			Key:         "event",
+			ValueKind:   reflect.String,
+			ValueString: "error",
+		},
+		{
+			Key:         "error",
+			ValueKind:   reflect.String,
+			ValueString: err.Error(),
+		},
+		{
+			Key:         "message",
+			ValueKind:   reflect.String,
+			ValueString: "my optional msg text",
+		},
+	}, fields)
+}

--- a/log/field.go
+++ b/log/field.go
@@ -143,6 +143,16 @@ func Object(key string, obj interface{}) Field {
 	}
 }
 
+// Event creates a string-valued Field for span logs with key="event" and value=val.
+func Event(val string) Field {
+	return String("event", val)
+}
+
+// Message creates a string-valued Field for span logs with key="message" and value=val.
+func Message(val string) Field {
+	return String("message", val)
+}
+
 // LazyLogger allows for user-defined, late-bound logging of arbitrary data
 type LazyLogger func(fv Encoder)
 

--- a/log/field_test.go
+++ b/log/field_test.go
@@ -34,6 +34,14 @@ func TestFieldString(t *testing.T) {
 			field:    Noop(),
 			expected: ":<nil>",
 		},
+		{
+			field:    Event("test"),
+			expected: "event:test",
+		},
+		{
+			field:    Message("test2"),
+			expected: "message:test2",
+		},
 	}
 	for i, tc := range testCases {
 		if str := tc.field.String(); str != tc.expected {


### PR DESCRIPTION
Opentracing spec specify prefered names for log messages [1]
This patch adds declaration for fields which are meaningful for golan

I've added only minimal subset of features as a first step,
For example this patch has no stacktrace logging for errors because  stacktrace generation is implementation depended, so caller should do it explicitly.
Footnotes:
[1] https://github.com/opentracing/specification/blob/master/semantic_conventions.md