### PR TITLE
Restore the ability to reset current span in context nil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 matrix:
   include:
-  - go: "1.11.x"
-  - go: "1.12.x"
+  - go: "1.13.x"
+  - go: "1.14.x"
   - go: "tip"
     env:
     - LINT=true

--- a/ext/field_test.go
+++ b/ext/field_test.go
@@ -37,7 +37,7 @@ func TestLogError(t *testing.T) {
 			ValueString: "error",
 		},
 		{
-			Key:         "error",
+			Key:         "error.object",
 			ValueKind:   reflect.String,
 			ValueString: err.Error(),
 		},

--- a/gocontext.go
+++ b/gocontext.go
@@ -7,10 +7,12 @@ type contextKey struct{}
 var activeSpanKey = contextKey{}
 
 // ContextWithSpan returns a new `context.Context` that holds a reference to
-// `span`'s SpanContext.
+// the span. If span is nil, a new context without an active span is returned.
 func ContextWithSpan(ctx context.Context, span Span) context.Context {
-	if tracerWithHook, ok := span.Tracer().(TracerContextWithSpanExtension); ok {
-		ctx = tracerWithHook.ContextWithSpanHook(ctx, span)
+	if span != nil {
+		if tracerWithHook, ok := span.Tracer().(TracerContextWithSpanExtension); ok {
+			ctx = tracerWithHook.ContextWithSpanHook(ctx, span)
+		}
 	}
 	return context.WithValue(ctx, activeSpanKey, span)
 }

--- a/gocontext_test.go
+++ b/gocontext_test.go
@@ -27,6 +27,11 @@ func TestContextWithSpan(t *testing.T) {
 	if span != span2 {
 		t.Errorf("Not the same span returned from context, expected=%+v, actual=%+v", span, span2)
 	}
+
+	ctx = ContextWithSpan(ctx, nil)
+	if s := SpanFromContext(ctx); s != nil {
+		t.Errorf("Not able to reset span in context, expected=nil, actual=%+v", s)
+	}
 }
 
 type noopExtTracer struct {


### PR DESCRIPTION
This got broken by #220. Adding a unit test.