### PR TITLE
Add started spans to mock tracer

### DIFF
--- a/mocktracer/mockspan.go
+++ b/mocktracer/mockspan.go
@@ -178,7 +178,7 @@ func (s *MockSpan) Finish() {
 	s.Lock()
 	s.FinishTime = time.Now()
 	s.Unlock()
-	s.tracer.recordSpan(s)
+	s.tracer.recordFinishedSpan(s)
 }
 
 // FinishWithOptions belongs to the Span interface
@@ -205,7 +205,7 @@ func (s *MockSpan) FinishWithOptions(opts opentracing.FinishOptions) {
 		}
 	}
 
-	s.tracer.recordSpan(s)
+	s.tracer.recordFinishedSpan(s)
 }
 
 // String allows printing span for debugging

--- a/mocktracer/mocktracer.go
+++ b/mocktracer/mocktracer.go
@@ -11,6 +11,7 @@ import (
 func New() *MockTracer {
 	t := &MockTracer{
 		finishedSpans: []*MockSpan{},
+		startedSpans:  []*MockSpan{},
 		injectors:     make(map[interface{}]Injector),
 		extractors:    make(map[interface{}]Extractor),
 	}
@@ -34,8 +35,18 @@ func New() *MockTracer {
 type MockTracer struct {
 	sync.RWMutex
 	finishedSpans []*MockSpan
+	startedSpans  []*MockSpan
 	injectors     map[interface{}]Injector
 	extractors    map[interface{}]Extractor
+}
+
+func (t *MockTracer) StartedSpans() []*MockSpan {
+	t.RLock()
+	defer t.RUnlock()
+
+	spans := make([]*MockSpan, len(t.startedSpans))
+	copy(spans, t.startedSpans)
+	return spans
 }
 
 // FinishedSpans returns all spans that have been Finish()'ed since the
@@ -54,6 +65,7 @@ func (t *MockTracer) FinishedSpans() []*MockSpan {
 func (t *MockTracer) Reset() {
 	t.Lock()
 	defer t.Unlock()
+	t.startedSpans = []*MockSpan{}
 	t.finishedSpans = []*MockSpan{}
 }
 
@@ -63,7 +75,10 @@ func (t *MockTracer) StartSpan(operationName string, opts ...opentracing.StartSp
 	for _, o := range opts {
 		o.Apply(&sso)
 	}
-	return newMockSpan(t, operationName, sso)
+
+	span := newMockSpan(t, operationName, sso)
+	t.recordStartedSpan(span)
+	return span
 }
 
 // RegisterInjector registers injector for given format
@@ -98,7 +113,13 @@ func (t *MockTracer) Extract(format interface{}, carrier interface{}) (opentraci
 	return extractor.Extract(carrier)
 }
 
-func (t *MockTracer) recordSpan(span *MockSpan) {
+func (t *MockTracer) recordStartedSpan(span *MockSpan) {
+	t.Lock()
+	defer t.Unlock()
+	t.startedSpans = append(t.startedSpans, span)
+}
+
+func (t *MockTracer) recordFinishedSpan(span *MockSpan) {
 	t.Lock()
 	defer t.Unlock()
 	t.finishedSpans = append(t.finishedSpans, span)

--- a/mocktracer/mocktracer.go
+++ b/mocktracer/mocktracer.go
@@ -40,7 +40,7 @@ type MockTracer struct {
 	extractors    map[interface{}]Extractor
 }
 
-// StartedSpans returns all spans that have been started and not finished since the
+// UnfinishedSpans returns all spans that have been started and not finished since the
 // MockTracer was constructed or since the last call to its Reset() method.
 func (t *MockTracer) UnfinishedSpans() []*MockSpan {
 	t.RLock()
@@ -127,7 +127,8 @@ func (t *MockTracer) recordFinishedSpan(span *MockSpan) {
 	t.finishedSpans = append(t.finishedSpans, span)
 
 	for i := range t.startedSpans {
-		if t.startedSpans[i].SpanContext.SpanID == span.SpanContext.SpanID {
+		if t.startedSpans[i].SpanContext.SpanID == span.SpanContext.SpanID &&
+			t.startedSpans[i].SpanContext.TraceID == span.SpanContext.TraceID {
 			t.startedSpans = append(t.startedSpans[:i], t.startedSpans[i+1:]...)
 			return
 		}

--- a/mocktracer/mocktracer.go
+++ b/mocktracer/mocktracer.go
@@ -1,7 +1,6 @@
 package mocktracer
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/opentracing/opentracing-go"
@@ -41,7 +40,9 @@ type MockTracer struct {
 	extractors    map[interface{}]Extractor
 }
 
-func (t *MockTracer) StartedSpans() []*MockSpan {
+// StartedSpans returns all spans that have been started and not finished since the
+// MockTracer was constructed or since the last call to its Reset() method.
+func (t *MockTracer) UnfinishedSpans() []*MockSpan {
 	t.RLock()
 	defer t.RUnlock()
 
@@ -58,16 +59,6 @@ func (t *MockTracer) FinishedSpans() []*MockSpan {
 	spans := make([]*MockSpan, len(t.finishedSpans))
 	copy(spans, t.finishedSpans)
 	return spans
-}
-
-func (t *MockTracer) AssertStartedSpansAreFinished() error {
-	startedSpans := t.StartedSpans()
-
-	if len(startedSpans) == 0 {
-		return nil
-	}
-
-	return fmt.Errorf("span %s was started but never finished", startedSpans[0].OperationName)
 }
 
 // Reset clears the internally accumulated finished spans. Note that any

--- a/mocktracer/mocktracer_test.go
+++ b/mocktracer/mocktracer_test.go
@@ -290,21 +290,12 @@ func TestMockSpan_Races(t *testing.T) {
 
 func TestMockTracer_AssertStartedSpansAreFinished(t *testing.T) {
 	tracer := New()
-	span1 := tracer.StartSpan("a")
-	span2 := newMockSpan(tracer, "b", opentracing.StartSpanOptions{})
+	span := tracer.StartSpan("a")
 
 	// fail due to no spans being finished
 	assert.Error(t, tracer.AssertStartedSpansAreFinished())
 
 	// pass due to the one started span being finished
-	span1.Finish()
+	span.Finish()
 	assert.NoError(t, tracer.AssertStartedSpansAreFinished())
-
-	// fail due to more finished spans than started spans
-	span2.Finish()
-	assert.Error(t, tracer.AssertStartedSpansAreFinished())
-
-	// fail due to started spans not equaling finished spans
-	tracer.StartSpan("c")
-	assert.Error(t, tracer.AssertStartedSpansAreFinished())
 }


### PR DESCRIPTION
My team has started using opentracing a bunch, but one problem we often run into is someone will forget to finish their started spans.  We noticed that in some cases that would cause the entire span to be dropped.  

I'm hoping to catch that in testing by providing a way to assert that every started span has a finished span, and to provide a nice error to point to which span was not finished.