### PR TITLE
Added http response size as external tag

### DIFF
--- a/ext/tags.go
+++ b/ext/tags.go
@@ -97,6 +97,10 @@ var (
 	// HTTP response.
 	HTTPStatusCode = Uint16TagName("http.status_code")
 
+	// HTTPResponseSize is the size of the response body in bytes of the
+	// HTTP response.
+	HTTPResponseSize = Uint16TagName("http.response_size")
+
 	//////////////////////////////////////////////////////////////////////
 	// DB Tags
 	//////////////////////////////////////////////////////////////////////

--- a/ext/tags_test.go
+++ b/ext/tags_test.go
@@ -48,6 +48,7 @@ func TestHTTPTags(t *testing.T) {
 	ext.HTTPUrl.Set(span, "test.biz/uri?protocol=false")
 	ext.HTTPMethod.Set(span, "GET")
 	ext.HTTPStatusCode.Set(span, 301)
+	ext.HTTPResponseSize.Set(span, 12345)
 	span.Finish()
 
 	rawSpan := tracer.FinishedSpans()[0]
@@ -55,6 +56,7 @@ func TestHTTPTags(t *testing.T) {
 		"http.url":         "test.biz/uri?protocol=false",
 		"http.method":      "GET",
 		"http.status_code": uint16(301),
+		"http.response_size": uint16(12345),
 		"span.kind":        ext.SpanKindRPCServerEnum,
 	}, rawSpan.Tags())
 }


### PR DESCRIPTION
Http response size is a useful metric and I think it's good to have it defined as external tag to keep it consistent.

Related to: https://github.com/opentracing-contrib/go-stdlib/pull/60