### PR TITLE
Fix lint warnings and re-enable failing CI on lint errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        continue-on-error: true
         with:
           version: latest
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  staticcheck:
+    checks: [ "all", "-SA1019" ]

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const testHeaderPrefix = "testprefix-"
-
 func TestTextMapCarrierInject(t *testing.T) {
 	m := make(map[string]string)
 	m["NotOT"] = "blah"


### PR DESCRIPTION
- disable deprecated function warnings since they are used in tests & api_checker and must remain
- re-enable failing CI on lint errors